### PR TITLE
Add JsonConverter attribute to CheckStatus enum

### DIFF
--- a/src/HealthCheck/CheckStatus.cs
+++ b/src/HealthCheck/CheckStatus.cs
@@ -1,5 +1,9 @@
-﻿namespace HealthChecks
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace HealthChecks
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CheckStatus
     {
         Unknown,


### PR DESCRIPTION
Hey @glennc, @anurse, @damienbod,

I've added JsonConverter attribute to [CheckStatus](https://github.com/aspnet/AspLabs/blob/master/src/HealthCheck/CheckStatus.cs) enum to show the text of the enum instead the id (You don't know what the id does mean).