### PR TITLE
Prototype of an ASP.NET Core shared framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@ TestResults/
 .nuget/
 .build/
 .testPublish/
+publish/
 *.sln.ide/
 _ReSharper.*/
 packages/
+shared/
 artifacts/
 PublishProfiles/
 .vs/

--- a/sharedfx/NuGet.config
+++ b/sharedfx/NuGet.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/sharedfx/build.ps1
+++ b/sharedfx/build.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+$artifacts = "$PSScriptRoot/artifacts"
+if (Test-Path $artifacts) {
+    Remove-Item -Recurse $artifacts
+}
+
+remove-item -Recurse $env:USERPROFILE/.nuget/packages/microsoft.aspnetcore.app/
+
+dotnet restore src/Microsoft.AspNetCore.App/
+dotnet pack src/Microsoft.AspNetCore.App/ -c Release -o $artifacts/build/
+dotnet publish src/Microsoft.AspNetCore.App/ -r win7-x64 -c Release -o $artifacts/shared/Microsoft.AspNetCore.App/2.0.0-preview1/

--- a/sharedfx/samples/NuGet.config
+++ b/sharedfx/samples/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="localbuild" value="../artifacts/build" />
+  </packageSources>
+</configuration>

--- a/sharedfx/samples/Web/Startup.cs
+++ b/sharedfx/samples/Web/Startup.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Http;
+
+namespace Web
+{
+    public class Startup
+    {
+        public static void Main()
+        {
+            WebHost.Start(context => context.Response.WriteAsync("Hello, World!"));
+        }
+    }
+}

--- a/sharedfx/samples/Web/Web.csproj
+++ b/sharedfx/samples/Web/Web.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <!-- prevent SDK from adding Microsoft.NETCore.App...just for now -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- we could easily make this an implicit import from Microsoft.NET.Sdk.Web -->
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.0.0-preview1" />
+  </ItemGroup>
+
+</Project>

--- a/sharedfx/samples/build.ps1
+++ b/sharedfx/samples/build.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+
+# Copy to the 'local' hive just for demoing
+if (!(Test-Path $PSScriptRoot/publish/shared)) {
+    mkdir $PSScriptRoot/publish/ -ErrorAction Ignore | Out-Null
+    copy-item -Recurse $PSScriptRoot/../artifacts/shared $PSScriptRoot/publish/
+}
+
+dotnet restore Web/
+dotnet publish Web/ -c Release -o $PSScriptRoot/publish/
+
+push-location $PSScriptRoot/publish/
+try {
+    dotnet Web.dll
+} finally {
+    pop-location
+}

--- a/sharedfx/src/Microsoft.AspNetCore.App/Microsoft.AspNetCore.App.csproj
+++ b/sharedfx/src/Microsoft.AspNetCore.App/Microsoft.AspNetCore.App.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Product>Microsoft ASP.NET Core</Product>
+    <Description>A set of APIs that describe the Microsoft.AspNetCore.App shared framework on .NET Core</Description>
+    <PackageTags>aspnetcore</PackageTags>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>preview1</VersionSuffix>
+    <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnableApiCheck>false</EnableApiCheck>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81</PackageTargetFallback>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <RuntimeIdentifiers>win7-x64;win7-x86;linux-x64;osx.10.10-x64</RuntimeIdentifiers>
+    <SelfContained>true</SelfContained>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+  </PropertyGroup>
+
+  <Import Project="dependencies.props" />
+
+  <ItemGroup>
+   <PackageReference Include="@(Dependencies)" />
+   <PackageReference Include="Microsoft.NETCore.App" Version="2.0.0-preview1-*" PrivateAssets="None" />
+   <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="2.0.0-preview1-*" PrivateAssets="All" />
+   <PackageReference Include="Microsoft.NETCore.Jit" Version="2.0.0-preview1-*" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\**\*.props" PackagePath="%(Identity)" />
+  </ItemGroup>
+
+  <Import Project="crossgen.targets" />
+
+</Project>

--- a/sharedfx/src/Microsoft.AspNetCore.App/build/netcoreapp2.0/Microsoft.AspNetCore.App.props
+++ b/sharedfx/src/Microsoft.AspNetCore.App/build/netcoreapp2.0/Microsoft.AspNetCore.App.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+     <MicrosoftNETPlatformLibrary>Microsoft.AspNetCore.App</MicrosoftNETPlatformLibrary>
+  </PropertyGroup>
+</Project>

--- a/sharedfx/src/Microsoft.AspNetCore.App/crossgen.targets
+++ b/sharedfx/src/Microsoft.AspNetCore.App/crossgen.targets
@@ -1,0 +1,75 @@
+<Project>
+  <PropertyGroup>
+    <CoreClrPackageName>runtime.$(RuntimeIdentifier).Microsoft.NETCore.Runtime.CoreCLR</CoreClrPackageName>
+    <JitPackageName>runtime.$(RuntimeIdentifier).Microsoft.NETCore.Jit</JitPackageName>
+  </PropertyGroup>
+
+  <Target Name="CrossGen" AfterTargets="Publish" DependsOnTargets="RunResolvePackageDependencies">
+
+    <Error Text="RuntimeIdentifier must be set" Condition="'$(RuntimeIdentifier)' == ''" />
+
+    <Message Importance="High" Text="Starting crossgen" />
+
+    <PropertyGroup>
+      <!-- 3B = semicolon in ASCII -->
+      <PathSeparator Condition="'$(PathSeparator)' == ''">:</PathSeparator>
+      <PathSeparator Condition="$(RuntimeIdentifier.StartsWith('win'))">%3B</PathSeparator>
+      <CrossGenIntermediatePath>$(IntermediateOutputPath)ni\</CrossGenIntermediatePath>
+      <CoreClrVersion>@(PackageDefinitions->WithMetadataValue('Name', '$(CoreClrPackageName)')->Metadata('Version'))</CoreClrVersion>
+      <CrossGenToolDir>$(IntermediateOutputPath)crossgen\</CrossGenToolDir>
+      <_CrossGenFileName>crossgen</_CrossGenFileName>
+      <_CrossGenFileName Condition="$(RuntimeIdentifier.StartsWith('win'))">$(_CrossGenFileName).exe</_CrossGenFileName>
+      <_CoreClrPackageRoot>@(PackageDefinitions->WithMetadataValue('Name', '$(CoreClrPackageName)')->Metadata('ResolvedPath'))</_CoreClrPackageRoot>
+      <_JitPackageRoot>@(PackageDefinitions->WithMetadataValue('Name', '$(JitPackageName)')->Metadata('ResolvedPath'))</_JitPackageRoot>
+      <CrossGenPath>$(CrossGenToolDir)$(_CrossGenFileName)</CrossGenPath>
+      <CrossGenRsp>$(IntermediateOutputPath)crossgen.rsp</CrossGenRsp>
+      <!-- because quoted arguments that end in \ actually need to be \\ to please the whims of cmd.exe -->
+      <_TrailingSlash Condition="$(RuntimeIdentifier.StartsWith('win'))">\</_TrailingSlash>
+      <PlatformArg>/Platform_Assemblies_Paths "$(PublishDir)$(PathSeparator)$(CrossGenToolDir)$(_TrailingSlash)"</PlatformArg>
+    </PropertyGroup>
+
+    <Error Text="Could not resolve $(CoreClrPackageName)" Condition="'$(_CoreClrPackageRoot)' == ''" />
+    <Error Text="Could not resolve $(JitPackageName)" Condition="'$(_JitPackageRoot)' == ''" />
+
+    <ItemGroup>
+      <_CrossGenFiles Include="$(_CoreClrPackageRoot)\tools\$(_CrossGenFileName)" />
+      <_CrossGenFiles Include="$(_CoreClrPackageRoot)\runtimes\$(RuntimeIdentifier)\**\*" />
+      <_CrossGenFiles Include="$(_JitPackageRoot)\runtimes\$(RuntimeIdentifier)\**\*" />
+      <PlatformAssemblies Include="$(PublishDir)*.dll" />
+      <PlatformAssemblies Include="$(PublishDir)*.exe" />
+    </ItemGroup>
+
+    <Message Importance="high" Text="CoreCLR Version: $(CoreClrVersion)"/>
+    <RemoveDir Directories="$(CrossGenToolDir)" />
+    <Copy SourceFiles="@(_CrossGenFiles)" DestinationFolder="$(CrossGenToolDir)" />
+    <Exec Command="chmod +x crossgen" WorkingDirectory="$(CrossGenToolDir)" Condition="'$(OS)' != 'Windows_NT'" />
+
+    <!-- make the rsp file for crossgen -->
+    <ItemGroup>
+      <CrossGenArgs Include="/nologo" />
+      <CrossGenArgs Include="/MissingDependenciesOK" />
+      <CrossGenArgs Include="$(PlatformArg)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(CrossGenRsp)" Lines="@(CrossGenArgs)" Overwrite="true" />
+
+    <Message Importance="low" Text="Running cross with args: @(CrossGenArgs, ' ')"/>
+    <Message Importance="normal" Text="@(PlatformAssemblies, '%0A')" />
+    <Message Importance="normal" Text="Crossgen path: $(CrossGenPath)"/>
+    <Message Importance="high" Text="Running crossgen on @(PlatformAssemblies->Count()) file(s)" />
+
+    <!-- Go! -->
+    <MakeDir Directories="$(CrossGenIntermediatePath)" />
+    <Exec Command="&quot;$(CrossGenPath)&quot; &quot;@$(CrossGenRsp)&quot; /in &quot;%(PlatformAssemblies.FullPath)&quot; /out &quot;$(CrossGenIntermediatePath)%(FileName)%(Extension)&quot;"
+      IgnoreExitCode="true"
+      IgnoreStandardErrorWarningFormat="true" />
+
+    <ItemGroup>
+      <CrossGened Include="$(CrossGenIntermediatePath)**\*" />
+    </ItemGroup>
+
+    <Move SourceFiles="@(CrossGened)" DestinationFolder="$(PublishDir)" />
+
+    <Message Text="Finished crossgening @(CrossGened->Count()) files in $(PublishDir) " Importance="High" />
+  </Target>
+</Project>

--- a/sharedfx/src/Microsoft.AspNetCore.App/dependencies.props
+++ b/sharedfx/src/Microsoft.AspNetCore.App/dependencies.props
@@ -1,0 +1,156 @@
+<Project>
+
+  <PropertyGroup>
+    <AspNetCoreVersion>$(VersionPrefix)-$(VersionSuffix)-*</AspNetCoreVersion>
+    <AspNetCoreIdentityServiceVersion>1.0.0-$(VersionSuffix)-*</AspNetCoreIdentityServiceVersion>
+  </PropertyGroup>
+
+  <!-- defines the default values for each item type -->
+  <ItemDefinitionGroup>
+    <!-- set PrivateAssets=None to ensure that all assets, including Build and Analyzer, are included in the nuspec -->
+    <Dependencies>
+      <Version>$(AspNetCoreVersion)</Version>
+      <PrivateAssets>None</PrivateAssets>
+    </Dependencies>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <Dependencies Include="Microsoft.AspNetCore" />
+    <Dependencies Include="Microsoft.AspNetCore.Antiforgery" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.Cookies" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.Core" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.Facebook" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.Google" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.OAuth" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication.Twitter" />
+    <Dependencies Include="Microsoft.AspNetCore.Authentication" />
+    <Dependencies Include="Microsoft.AspNetCore.Authorization" />
+    <Dependencies Include="Microsoft.AspNetCore.CookiePolicy" />
+    <Dependencies Include="Microsoft.AspNetCore.Cors" />
+    <Dependencies Include="Microsoft.AspNetCore.Cryptography.Internal" />
+    <Dependencies Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" />
+    <Dependencies Include="Microsoft.AspNetCore.DataProtection.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.DataProtection.AzureStorage" />
+    <Dependencies Include="Microsoft.AspNetCore.DataProtection.Extensions" />
+    <Dependencies Include="Microsoft.AspNetCore.DataProtection" />
+    <Dependencies Include="Microsoft.AspNetCore.Diagnostics.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />
+    <Dependencies Include="Microsoft.AspNetCore.Diagnostics.Identity.Service" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Diagnostics" />
+    <Dependencies Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Hosting" />
+    <Dependencies Include="Microsoft.AspNetCore.Html.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Http.Extensions" />
+    <Dependencies Include="Microsoft.AspNetCore.Http.Features" />
+    <Dependencies Include="Microsoft.AspNetCore.Http" />
+    <Dependencies Include="Microsoft.AspNetCore.HttpOverrides" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.Service.Abstractions" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.Service.Core" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.Service.IntegratedWebClient" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.Service.Mvc" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity.Service" Version="$(AspNetCoreIdentityServiceVersion)" />
+    <Dependencies Include="Microsoft.AspNetCore.Identity" />
+    <Dependencies Include="Microsoft.AspNetCore.JsonPatch" />
+    <Dependencies Include="Microsoft.AspNetCore.Localization.Routing" />
+    <Dependencies Include="Microsoft.AspNetCore.Localization" />
+    <Dependencies Include="Microsoft.AspNetCore.MiddlewareAnalysis" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Core" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Cors" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.DataAnnotations" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Formatters.Json" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Localization" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.Razor" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.RazorPages" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <Dependencies Include="Microsoft.AspNetCore.Mvc" />
+    <Dependencies Include="Microsoft.AspNetCore.Owin" />
+    <Dependencies Include="Microsoft.AspNetCore.Razor.Language" />
+    <Dependencies Include="Microsoft.AspNetCore.Razor.Runtime" />
+    <Dependencies Include="Microsoft.AspNetCore.Razor" />
+    <Dependencies Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.ResponseCaching" />
+    <Dependencies Include="Microsoft.AspNetCore.ResponseCompression" />
+    <Dependencies Include="Microsoft.AspNetCore.Rewrite" />
+    <Dependencies Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Routing" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.HttpSys" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.IISIntegration" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.Kestrel.Https" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
+    <Dependencies Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <Dependencies Include="Microsoft.AspNetCore.Session" />
+    <Dependencies Include="Microsoft.AspNetCore.StaticFiles" />
+    <Dependencies Include="Microsoft.AspNetCore.WebSockets" />
+    <Dependencies Include="Microsoft.AspNetCore.WebUtilities" />
+    <Dependencies Include="Microsoft.CodeAnalysis.Razor" />
+    <Dependencies Include="Microsoft.Data.Sqlite.Core" />
+    <Dependencies Include="Microsoft.Data.Sqlite" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Design" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Relational.Design" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Relational" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Sqlite.Core" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Sqlite.Design" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.SqlServer.Design" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore.Tools" />
+    <Dependencies Include="Microsoft.EntityFrameworkCore" />
+    <Dependencies Include="Microsoft.Extensions.Caching.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.Caching.Memory" />
+    <Dependencies Include="Microsoft.Extensions.Caching.Redis" />
+    <Dependencies Include="Microsoft.Extensions.Caching.SqlServer" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.Binder" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.DockerSecrets" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.Ini" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <Dependencies Include="Microsoft.Extensions.Configuration.Xml" />
+    <Dependencies Include="Microsoft.Extensions.Configuration" />
+    <Dependencies Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependencies Include="Microsoft.Extensions.DiagnosticAdapter" />
+    <Dependencies Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.FileProviders.Composite" />
+    <Dependencies Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <Dependencies Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependencies Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <Dependencies Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.Localization.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.Localization" />
+    <Dependencies Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependencies Include="Microsoft.Extensions.Logging.Console" />
+    <Dependencies Include="Microsoft.Extensions.Logging.Debug" />
+    <Dependencies Include="Microsoft.Extensions.Logging.EventSource" />
+    <Dependencies Include="Microsoft.Extensions.Logging.TraceSource" />
+    <Dependencies Include="Microsoft.Extensions.Logging" />
+    <Dependencies Include="Microsoft.Extensions.ObjectPool" />
+    <Dependencies Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <Dependencies Include="Microsoft.Extensions.Options" />
+    <Dependencies Include="Microsoft.Extensions.Primitives" />
+    <Dependencies Include="Microsoft.Extensions.WebEncoders" />
+    <Dependencies Include="Microsoft.Net.Http.Headers" />
+    <Dependencies Include="Microsoft.VisualStudio.Web.BrowserLink" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This code creates a .NET Core shared framework that includes everything Microsoft.AspNetCore.All already has.

Sample csproj (today)
```xml
<Project Sdk="Microsoft.NET.Sdk.Web">
  <PropertyGroup>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.0.0-preview1" />
  </ItemGroup>
</Project>
```

If we added the implicit import to Microsoft.NET.Sdk.Web:
```xml
<Project Sdk="Microsoft.NET.Sdk.Web">
  <PropertyGroup>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>
</Project>
```

Trimmed output:
<img src="https://cloud.githubusercontent.com/assets/2696087/25768535/b2fb6ada-31ba-11e7-978e-ff7e0a098bca.png" width="220" />

Installed to dotnet folder:
<img src="https://cloud.githubusercontent.com/assets/2696087/25768545/ce90e806-31ba-11e7-939b-c9e27468d540.png" width="194" />


cc @davidfowl @DamianEdwards 