### PR TITLE
Produce an LZMA with the refonly package

### DIFF
--- a/pkg/.gitignore
+++ b/pkg/.gitignore
@@ -1,5 +1,3 @@
-feed/
-publish/
 obj/
 ref/
 .dotnet/

--- a/pkg/build.ps1
+++ b/pkg/build.ps1
@@ -14,29 +14,75 @@ if (-not (Test-Path $nuget)) {
     iwr -o $nuget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 }
 
-$dotnet = "$PSScriptRoot/.dotnet/dotnet"
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+$env:MSBUILDDISABLENODEREUSE = 1
+$env:UseRazorBuildServer='false'
+
+# Install a hackable copy of the 2.1.300 SDK. We're going to mess with it, so don't use the machine installed version
+Write-Host ""
+Write-Host -f Cyan "Setting up a local copy of the .NET Core 2.1.300 SDK that we're going to hack to pieces"
+Write-Host ""
 $dotnetInstall = "$PSScriptRoot/obj/dotnet-install.ps1"
 if (-not (Test-Path $dotnetInstall)) {
     iwr -o $dotnetInstall https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1
 }
 & $dotnetInstall -installdir "$PSScriptRoot/.dotnet" -version 2.1.300
+$dotnet = Resolve-Path "$PSScriptRoot/.dotnet/dotnet.exe"
+
+# Let's make a shared framework that is functionally the same as Microsoft.AspNetCore.App, but is referenced from a package that does not have nupkg dependencies
+Write-Host ""
+Write-Host -f Cyan "Creating the 'RefOnly' version of AspNetCore.App"
+Write-Host ""
 Copy-Item -Recurse "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App/*" "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App.RefOnly" -ea Ignore
 mv "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App.RefOnly/2.1.0/Microsoft.AspNetCore.App.deps.json" "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App.RefOnly/2.1.0/Microsoft.AspNetCore.App.RefOnly.deps.json" -ea Ignore
 mv "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App.RefOnly/2.1.0/Microsoft.AspNetCore.App.runtimeconfig.json" "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App.RefOnly/2.1.0/Microsoft.AspNetCore.App.RefOnly.runtimeconfig.json" -ea Ignore
-$refsPublish = "$PSScriptRoot/Microsoft.AspNetCore.App.RefOnly/ref/netcoreapp2.1"
-Invoke-Block { & $dotnet publish Microsoft.AspNetCore.App.RefOnly/Microsoft.AspNetCore.App.RefOnly.csproj --output $refsPublish }
+$refsPublish = "$PSScriptRoot/src/Microsoft.AspNetCore.App.RefOnly/ref/netcoreapp2.1"
+Invoke-Block { & $dotnet publish src/Microsoft.AspNetCore.App.RefOnly/Microsoft.AspNetCore.App.RefOnly.csproj --output $refsPublish -nologo -v:q }
 rm "$refsPublish/Microsoft.AspNetCore.App.RefOnly.dll"
+rm "$refsPublish/Microsoft.AspNetCore.App.RefOnly.pdb"
 rm "$refsPublish/runtimes/" -Recurse
 rm "$refsPublish/*.json"
-Invoke-Block { & $nuget pack "$PSScriptRoot/Microsoft.AspNetCore.App.RefOnly/Microsoft.AspNetCore.App.RefOnly.nuspec" -OutputDirectory "$PSScriptRoot/feed" }
-
+Remove-Item -Recurse -Force "$PSScriptRoot/obj/feed" -ea ignore
+Invoke-Block { & $nuget pack "$PSScriptRoot/src/Microsoft.AspNetCore.App.RefOnly/Microsoft.AspNetCore.App.RefOnly.nuspec" -OutputDirectory "$PSScriptRoot/obj/feed" -NoPackageAnalysis }
 rm $env:USERPROFILE/.nuget/packages/Microsoft.AspNetCore.App.RefOnly -Recurse -ea ignore
-Invoke-Block { & $dotnet publish test/test.csproj -o "$(pwd)/publish/" }
 
-pushd publish
-try {
-    Invoke-Block { & $dotnet test.dll }
+# Save a backup copy of the .lzma, just for comparison
+$bigLzma = "$PSScriptRoot/.dotnet/sdk/2.1.300/nuGetPackagesArchive.lzma.bak"
+$newLzma = "$PSScriptRoot/.dotnet/sdk/2.1.300/nuGetPackagesArchive.lzma"
+if (-not (Test-Path $bigLzma)) {
+    Copy-Item "$PSScriptRoot/.dotnet/sdk/2.1.300/nuGetPackagesArchive.lzma" $bigLzma
 }
-finally {
-    popd
-}
+Remove-Item "$PSScriptRoot/.dotnet/sdk/2.1.300/nuGetPackagesArchive.lzma" -ea Ignore
+
+# Build the LZMA using this ref-only package
+Write-Host ""
+Write-Host -f Cyan "Building a new LZMA"
+Write-Host ""
+$lzmaStagingDir = "$PSScriptRoot/obj/packages"
+Remove-Item -Recurse -Force $lzmaStagingDir -ea ignore
+Invoke-Block { & $dotnet restore src/lzma/refs/refs.csproj }
+Invoke-Block { & $dotnet run -p src/lzma/redist/redist.csproj -- $lzmaStagingDir $newLzma }
+
+$oldSize = (Get-ChildItem $bigLzma).Length
+$newSize = (Get-ChildItem $newLzma).Length
+Write-Host -ForegroundColor Magenta ("Old LZMA  = {0:F2} MB" -f ($oldSize/1mb))
+Write-Host -ForegroundColor Magenta ("New LZMA   = {0:F2} MB" -f ($newSize/1mb))
+Write-Host -ForegroundColor Magenta ("Comparison = {0:P}" -f ($newSize/$oldSize))
+
+# Build our test mvc app, with the first-run experience enabled
+Write-Host ""
+Write-Host -f Cyan "Building a sample MVC app"
+Write-Host ""
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 0
+Remove-Item -Recurse -Force "$PSScriptRoot/.dotnet/sdk/NuGetFallbackFolder" -ea ignore
+Invoke-Block { & $dotnet publish testapp/MvcWebApp/MvcWebApp.csproj -o "$PSScriptRoot/obj/publish/" }
+
+Write-Host ""
+Write-Host -f Cyan "Done"
+Write-Host ""
+Write-Host ""
+Write-Host "You can now run a sample app by calling in `"$PSScriptRoot/obj/publish/`""
+Write-Host "  cd `"$PSScriptRoot\obj\publish`""
+Write-Host "  $dotnet MvcWebApp.dll"
+Write-Host ""

--- a/pkg/src/Microsoft.AspNetCore.App.RefOnly/Microsoft.AspNetCore.App.RefOnly.csproj
+++ b/pkg/src/Microsoft.AspNetCore.App.RefOnly/Microsoft.AspNetCore.App.RefOnly.csproj
@@ -9,4 +9,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     </ItemGroup>
+
+    <Target Name="PublishXmlDocsToo" AfterTargets="Publish">
+        <ItemGroup>
+            <XmlDocFile Include="%(ResolvedAssembliesToPublish.RootDir)%(ResolvedAssembliesToPublish.Directory)%(ResolvedAssembliesToPublish.FileName).xml" />
+        </ItemGroup>
+        <Copy SourceFiles="@(XmlDocFile)" DestinationFolder="$(PublishDir)" Condition="Exists('%(XmlDocFile.Identity)')" />
+    </Target>
 </Project>

--- a/pkg/src/lzma/redist/Program.cs
+++ b/pkg/src/lzma/redist/Program.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using Microsoft.DotNet.Archive;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        var source = Path.GetFullPath(args[0]).TrimEnd(new []{ '\\', '/' });
+        var outputPath = Path.GetFullPath(args[1]);
+
+        var progress = new ConsoleProgressReport();
+        using (var archive = new IndexedArchive())
+        {
+            Console.WriteLine($"Adding directory: {source}");
+            archive.AddDirectory(source, progress);
+            archive.Save(outputPath, progress);
+        }
+    }
+}

--- a/pkg/src/lzma/redist/redist.csproj
+++ b/pkg/src/lzma/redist/redist.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>exe</OutputType>
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Archive" Version="0.2.0-beta-62628-01" />
+  </ItemGroup>
+
+</Project>

--- a/pkg/src/lzma/refs/refs.csproj
+++ b/pkg/src/lzma/refs/refs.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RestoreSources>https://api.nuget.org/v3/index.json;$(MSBuildProjectDirectory)\..\..\..\obj\feed\</RestoreSources>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <RestorePackagesPath>$(MSBuildThisFileDirectory)..\..\..\obj\packages\</RestorePackagesPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App.RefOnly" Version="2.1.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Comparison:

## Old LZMA
See https://github.com/aspnet/Universe/issues/1124 for more details on the composition of the current NuGetFallbackFolder
* 1,010 MB once expanded on disk
  * ~670 MB of xml docs
  * 181 MB of binaries
## LZMA with Microsoft.AspNetCore.App.RefOnly

* 113 MB once expanded on disk
  * 49 MB of xml docs
  * 41MB of binaries

*And it can still get smaller!* This prototype still bundles the implementation binaries in Microsoft.AspNetCore.App.RefOnly. We could strip these down to actual ref assemblies.


<img src="https://user-images.githubusercontent.com/2696087/41493480-88802cea-70bc-11e8-9bb5-aa24831549c6.png" width="500" />

<img src="https://user-images.githubusercontent.com/2696087/41493485-971cac88-70bc-11e8-8117-c13c4b2bd368.png" width="350" />



@DamianEdwards @Petermarcu @davidfowl @weshaggard