### PR TITLE
dotnet-dump for windows/linux, full dumps only

### DIFF
--- a/src/dotnet-monitor/Directory.Build.props
+++ b/src/dotnet-monitor/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <RuntimeFrameworkVersion>2.2.0-preview3-26913-03</RuntimeFrameworkVersion>
     </PropertyGroup>
 </Project>

--- a/src/dotnet-monitor/dotnet-monitor.sln
+++ b/src/dotnet-monitor/dotnet-monitor.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleWebApp", "samples\Sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-analyze", "src\dotnet-analyze\dotnet-analyze.csproj", "{D894FA6D-6B63-450B-93A7-4120C2CDC147}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-dump", "src\dotnet-dump\dotnet-dump.csproj", "{933327B7-87FC-4D1B-8AF4-C6A07DE30AA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{D894FA6D-6B63-450B-93A7-4120C2CDC147}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D894FA6D-6B63-450B-93A7-4120C2CDC147}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D894FA6D-6B63-450B-93A7-4120C2CDC147}.Release|Any CPU.Build.0 = Release|Any CPU
+		{933327B7-87FC-4D1B-8AF4-C6A07DE30AA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{933327B7-87FC-4D1B-8AF4-C6A07DE30AA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{933327B7-87FC-4D1B-8AF4-C6A07DE30AA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{933327B7-87FC-4D1B-8AF4-C6A07DE30AA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,6 +78,7 @@ Global
 		{820A83F4-832E-4984-9E43-C631C356A004} = {A9AE5A6B-48A3-424D-BD94-1A7E10921551}
 		{993C97DD-A837-4C8B-97DA-6F11AD797485} = {2AB63881-E835-4F6C-9362-4A16156A3F2D}
 		{D894FA6D-6B63-450B-93A7-4120C2CDC147} = {A9AE5A6B-48A3-424D-BD94-1A7E10921551}
+		{933327B7-87FC-4D1B-8AF4-C6A07DE30AA4} = {A9AE5A6B-48A3-424D-BD94-1A7E10921551}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0491437C-33E9-4E6E-967C-65A7875110CE}

--- a/src/dotnet-monitor/samples/SampleWebApp/Pages/Error.cshtml.cs
+++ b/src/dotnet-monitor/samples/SampleWebApp/Pages/Error.cshtml.cs
@@ -14,7 +14,6 @@ namespace SampleWebApp.Pages
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public void OnGet()
         {
             RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;

--- a/src/dotnet-monitor/src/Common/ConsoleCancellation.cs
+++ b/src/dotnet-monitor/src/Common/ConsoleCancellation.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.Threading;
+using McMaster.Extensions.CommandLineUtils;
 
 namespace Microsoft.Internal.Utilities
 {
     public static class ConsoleCancellationExtensions
     {
-        public static CancellationToken GetCtrlCToken()
+        public static CancellationToken GetCtrlCToken(this IConsole console)
         {
             var cts = new CancellationTokenSource();
-            Console.CancelKeyPress += (sender, args) =>
+            console.CancelKeyPress += (sender, args) =>
             {
                 if (cts.IsCancellationRequested)
                 {

--- a/src/dotnet-monitor/src/dotnet-dump/Dumper.Linux.cs
+++ b/src/dotnet-monitor/src/dotnet-dump/Dumper.Linux.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace Microsoft.Diagnostics.Tools.Dump
+{
+    public static partial class Dumper
+    {
+        private static class Linux
+        {
+            internal static async Task CollectDumpAsync(Process process, string fileName)
+            {
+                // We don't work on WSL :(
+                var ostype = await File.ReadAllTextAsync("/proc/sys/kernel/osrelease");
+                if(ostype.Contains("Microsoft"))
+                {
+                    throw new PlatformNotSupportedException("Cannot collect memory dumps from Windows Subsystem for Linux.");
+                }
+
+                // First step is to find the .NET runtime. To do this we look for coreclr.so
+                var coreclr = process.Modules.Cast<ProcessModule>().FirstOrDefault(m => string.Equals(m.ModuleName, "libcoreclr.so"));
+                if(coreclr == null)
+                {
+                    throw new NotSupportedException("Unable to locate .NET runtime associated with this process!");
+                }
+
+                // Find createdump next to that file
+                var runtimeDirectory = Path.GetDirectoryName(coreclr.FileName);
+                var createDumpPath = Path.Combine(runtimeDirectory, "createdump");
+                if(!File.Exists(createDumpPath))
+                {
+                    throw new NotSupportedException($"Unable to locate 'createdump' tool in '{runtimeDirectory}'");
+                }
+
+                // Create the dump
+                var exitCode = await CreateDumpAsync(createDumpPath, fileName, process.Id);
+                if(exitCode != 0)
+                {
+                    throw new Exception($"createdump exited with non-zero exit code: {exitCode}");
+                }
+            }
+
+            private static Task<int> CreateDumpAsync(string exePath, string fileName, int processId)
+            {
+                var tcs = new TaskCompletionSource<int>();
+                var createdump = new Process()
+                {
+                    StartInfo = new ProcessStartInfo()
+                    {
+                        FileName = exePath,
+                        Arguments = $"-f {fileName} {processId}",
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardInput = true,
+                    },
+                    EnableRaisingEvents = true,
+                };
+                createdump.Exited += (s, a) => tcs.TrySetResult(createdump.ExitCode);
+                createdump.Start();
+                return tcs.Task;
+            }
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-dump/Dumper.Windows.cs
+++ b/src/dotnet-monitor/src/dotnet-dump/Dumper.Windows.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Diagnostics.Tools.Dump
+{
+    public static partial class Dumper
+    {
+        private static class Windows
+        {
+            internal static Task CollectDumpAsync(Process process, string outputFile)
+            {
+                // We can't do this "asynchronously" so just Task.Run it. It shouldn't be "long-running" so this is fairly safe.
+                return Task.Run(() =>
+                {
+                    // Open the file for writing
+                    using (var stream = new FileStream(outputFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+                    {
+                        // Dump the process!
+                        var exceptionInfo = new NativeMethods.MINIDUMP_EXCEPTION_INFORMATION();
+                        if (!NativeMethods.MiniDumpWriteDump(process.Handle, (uint)process.Id, stream.SafeFileHandle, NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemory, ref exceptionInfo, IntPtr.Zero, IntPtr.Zero))
+                        {
+                            var err = Marshal.GetHRForLastWin32Error();
+                            Marshal.ThrowExceptionForHR(err);
+                        }
+                    }
+                });
+            }
+
+            private static class NativeMethods
+            {
+                [DllImport("Dbghelp.dll")]
+                public static extern bool MiniDumpWriteDump(IntPtr hProcess, uint ProcessId, SafeFileHandle hFile, MINIDUMP_TYPE DumpType, ref MINIDUMP_EXCEPTION_INFORMATION ExceptionParam, IntPtr UserStreamParam, IntPtr CallbackParam);
+
+                [StructLayout(LayoutKind.Sequential, Pack = 4)]
+                public struct MINIDUMP_EXCEPTION_INFORMATION
+                {
+                    public uint ThreadId;
+                    public IntPtr ExceptionPointers;
+                    public int ClientPointers;
+                }
+
+                public enum MINIDUMP_TYPE : uint
+                {
+                    MiniDumpNormal,
+                    MiniDumpWithDataSegs,
+                    MiniDumpWithFullMemory,
+                    MiniDumpWithHandleData,
+                    MiniDumpFilterMemory,
+                    MiniDumpScanMemory,
+                    MiniDumpWithUnloadedModules,
+                    MiniDumpWithIndirectlyReferencedMemory,
+                    MiniDumpFilterModulePaths,
+                    MiniDumpWithProcessThreadData,
+                    MiniDumpWithPrivateReadWriteMemory,
+                    MiniDumpWithoutOptionalData,
+                    MiniDumpWithFullMemoryInfo,
+                    MiniDumpWithThreadInfo,
+                    MiniDumpWithCodeSegs,
+                    MiniDumpWithoutAuxiliaryState,
+                    MiniDumpWithFullAuxiliaryState,
+                    MiniDumpWithPrivateWriteCopyMemory,
+                    MiniDumpIgnoreInaccessibleMemory,
+                    MiniDumpWithTokenInformation,
+                    MiniDumpWithModuleHeaders,
+                    MiniDumpFilterTriage,
+                    MiniDumpWithAvxXStateContext,
+                    MiniDumpWithIptTrace,
+                    MiniDumpValidTypeFlags
+                }
+            }
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-dump/Dumper.cs
+++ b/src/dotnet-monitor/src/dotnet-dump/Dumper.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Dump
+{
+    public static partial class Dumper
+    {
+        public static Task CollectDumpAsync(Process process, string fileName)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Windows.CollectDumpAsync(process, fileName);
+            }
+            else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Linux.CollectDumpAsync(process, fileName);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException("Can't collect a memory dump on this platform.");
+            }
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-dump/Program.cs
+++ b/src/dotnet-monitor/src/dotnet-dump/Program.cs
@@ -1,0 +1,61 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Internal.Utilities;
+
+namespace Microsoft.Diagnostics.Tools.Dump
+{
+    [Command(Name = "dotnet-dump", Description = "Captures memory dumps of .NET processes")]
+    internal class Program
+    {
+        [Required(ErrorMessage = "You must provide a process ID to be dumped.")]
+        [Option("-p|--process-id <PROCESS_ID>", Description = "The ID of the process to collect a memory dump for")]
+        public int ProcessId { get; set; }
+
+        [Option("-o|--output <OUTPUT_DIRECTORY>", Description = "The directory to write the dump to. Defaults to the current working directory.")]
+        public string OutputDir { get; set; }
+
+        public async Task<int> OnExecute(IConsole console, CommandLineApplication app)
+        {
+            if (string.IsNullOrEmpty(OutputDir))
+            {
+                OutputDir = Directory.GetCurrentDirectory();
+            }
+
+            // Get the process
+            var process = Process.GetProcessById(ProcessId);
+
+            // Generate the file name
+            var fileName = Path.Combine(OutputDir, $"{process.ProcessName}-{process.Id}-{DateTime.Now:yyyyMMdd-HHmmss-fff}.dmp");
+
+            console.WriteLine($"Collecting memory dump for {process.ProcessName} (ID: {process.Id}) ...");
+            await Dumper.CollectDumpAsync(process, fileName);
+            console.WriteLine($"Dump saved to {fileName}");
+
+            return 0;
+        }
+
+        private static int Main(string[] args)
+        {
+            DebugUtil.WaitForDebuggerIfRequested(ref args);
+
+            try
+            {
+                return CommandLineApplication.Execute<Program>(args);
+            }
+            catch(PlatformNotSupportedException ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return 1;
+            }
+            catch (OperationCanceledException)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-dump/dotnet-dump.csproj
+++ b/src/dotnet-monitor/src/dotnet-dump/dotnet-dump.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>Microsoft.Diagnostics.Tools.Dump</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Common\ConsoleCancellation.cs" Link="ConsoleCancellation.cs" />
+    <Compile Include="..\Common\DebugUtil.cs" Link="DebugUtil.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet-monitor/src/dotnet-trace/CollectCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-trace/CollectCommand.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Diagnostics.Transport.Protocol;
+using Microsoft.Internal.Utilities;
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {

--- a/src/dotnet-monitor/src/dotnet-trace/SourcesCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-trace/SourcesCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Internal.Utilities;
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {


### PR DESCRIPTION
Early prototype of `dotnet-dump`. Supports Windows only and just captures a dump of all memory.

Based on anurse/add-dotnet-monitor