### PR TITLE
dotnet-analyze - A CLRMD-based SOS-like REPL tool

### DIFF
--- a/src/dotnet-monitor/README.md
+++ b/src/dotnet-monitor/README.md
@@ -49,6 +49,34 @@ Options:
 
  The default behavior is to put traces in the directory from which you launched `dotnet-collect`. Traces are in files of the form `[appname].[processId].netperf` and can be viewed with [PerfView](https://github.com/Microsoft/PerfView).
 
- ## [dotnet-analyze](src/dotnet-analyze)
+## [dotnet-analyze](src/dotnet-analyze)
 
- A tool to analyze crash dumps, event traces, etc. for useful information. Right now it just has an analyzer that looks for incomplete async state machines (like DumpAsync in SOS). We are exploring providing more SOS-like functionality here (perhaps a managed SOS-style repl?)
+An SOS-like "REPL" for exploring .NET memory dumps (based on [CLRMD](https://github.com/Microsoft/clrmd)).
+
+```
+Inspect a crash dump using interactive commands
+
+Usage: dotnet-analyze [arguments] [options]
+
+Arguments:
+<DUMP>        The path to the dump file to analyze.
+
+Options:
+  -?|-h|--help  Show help information
+```
+
+When you launch this command, a REPL prompt is provided:
+
+```
+Loading crash dump C:\Users\anurse\Desktop\dotnet-18956-20181012-153829-088.dmp...
+Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.
+Type 'quit' or 'exit' to exit the analysis session.
+>
+```
+
+The following commands are available:
+* `quit` (alias `exit`) - Exit the tool
+* `help` - List commands and help information (not yet implemented ;))
+* `threads` (alias `~`) - List thread
+* `DumpStack` - Dump managed stack trace for the current thread. A little like SOS's `!DumpStack`
+* `DumpHeap` - Dump information about objects on the heap, grouped by type. A little like SOS's `!DumpHeap -stat`

--- a/src/dotnet-monitor/src/dotnet-analyze/AnalysisSession.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/AnalysisSession.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.Tools.Analyze
@@ -9,11 +10,24 @@ namespace Microsoft.Diagnostics.Tools.Analyze
     {
         public DataTarget Target { get; }
         public ClrRuntime Runtime { get; }
+        public int ActiveThreadId { get; set; }
+        public ClrThread ActiveThread => GetThread(ActiveThreadId);
 
         public AnalysisSession(DataTarget target, ClrRuntime runtime)
         {
             Target = target;
             Runtime = runtime;
+
+            var firstThread = runtime.Threads.FirstOrDefault();
+            if(firstThread != null)
+            {
+                ActiveThreadId = firstThread.ManagedThreadId;
+            }
+        }
+
+        public ClrThread GetThread(int id)
+        {
+            return Runtime.Threads.FirstOrDefault(t => t.ManagedThreadId == id);
         }
     }
 }

--- a/src/dotnet-monitor/src/dotnet-analyze/AnalysisSession.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/AnalysisSession.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Tools.Analyze
+{
+    public class AnalysisSession
+    {
+        public DataTarget Target { get; }
+        public ClrRuntime Runtime { get; }
+
+        public AnalysisSession(DataTarget target, ClrRuntime runtime)
+        {
+            Target = target;
+            Runtime = runtime;
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/CommandProcessor.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/CommandProcessor.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Diagnostics.Tools.Analyze.Commands;
+
+namespace Microsoft.Diagnostics.Tools.Analyze
+{
+    internal static class CommandProcessor
+    {
+        private static readonly IDictionary<string, IAnalysisCommand> _commands = BuildCommandList(
+            new HelpCommand());
+
+        public static async Task RunAsync(IConsole console, AnalysisSession session, CancellationToken cancellationToken = default)
+        {
+            await console.Out.WriteLineAsync("Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.");
+            await console.Out.WriteLineAsync("Type 'quit' or 'exit' to exit the analysis session.");
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await console.Out.WriteAsync("> ");
+                var line = await console.In.ReadLineAsync();
+
+                // Naive arg parsing
+                var args = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if(string.Equals(args[0], "quit", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "exit", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+                if(_commands.TryGetValue(args[0], out var command))
+                {
+                    await command.RunAsync(console, args.Skip(1).ToArray(), session);
+                }
+                else
+                {
+                    console.Error.WriteLine($"Unknown command: {args[0]}");
+                }
+            }
+        }
+
+        private static IDictionary<string, IAnalysisCommand> BuildCommandList(params IAnalysisCommand[] commands)
+        {
+            return commands.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/CommandProcessor.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/CommandProcessor.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Diagnostics.Tools.Analyze
         private static readonly IDictionary<string, IAnalysisCommand> _commands = BuildCommandList(
             new HelpCommand(),
             new ThreadsCommand(),
+            new DumpHeapCommand(),
             new DumpStackCommand());
 
         public static async Task RunAsync(IConsole console, AnalysisSession session, CancellationToken cancellationToken = default)

--- a/src/dotnet-monitor/src/dotnet-analyze/CommandProcessor.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/CommandProcessor.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Diagnostics.Tools.Analyze
     internal static class CommandProcessor
     {
         private static readonly IDictionary<string, IAnalysisCommand> _commands = BuildCommandList(
-            new HelpCommand());
+            new HelpCommand(),
+            new ThreadsCommand(),
+            new DumpStackCommand());
 
         public static async Task RunAsync(IConsole console, AnalysisSession session, CancellationToken cancellationToken = default)
         {
@@ -27,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Analyze
 
                 // Naive arg parsing
                 var args = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if(string.Equals(args[0], "quit", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "exit", StringComparison.OrdinalIgnoreCase))
+                if(string.Equals(args[0], "quit", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "q", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "exit", StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }
@@ -44,7 +46,15 @@ namespace Microsoft.Diagnostics.Tools.Analyze
 
         private static IDictionary<string, IAnalysisCommand> BuildCommandList(params IAnalysisCommand[] commands)
         {
-            return commands.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+            var dict = new Dictionary<string, IAnalysisCommand>(StringComparer.OrdinalIgnoreCase);
+            foreach(var command in commands)
+            {
+                foreach(var name in command.Names)
+                {
+                    dict[name] = command;
+                }
+            }
+            return dict;
         }
     }
 }

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpHeapCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpHeapCommand.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Microsoft.Diagnostics.Tools.Analyze.Commands
+{
+    public class DumpHeapCommand : IAnalysisCommand
+    {
+        public IEnumerable<string> Names { get; } = new[] { "DumpHeap" };
+
+        public Task RunAsync(IConsole console, string[] args, AnalysisSession session)
+        {
+            var stats = session.ComputeHeapStatistics().OrderBy(s => s.TotalSize);
+            console.WriteLine("              MT    Count    TotalSize Class Name");
+            foreach (var heapStats in stats)
+            {
+                console.WriteLine($"{heapStats.Type.MethodTable:X16} {heapStats.Count.ToString().PadLeft(8)} {heapStats.TotalSize.ToString().PadLeft(12)} {heapStats.Type.Name}");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpStackCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpStackCommand.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Tools.Analyze.Commands
 {
     public class DumpStackCommand : IAnalysisCommand
     {
-        public IEnumerable<string> Names { get; } = new List<string>() { "dumpstack" };
+        public IEnumerable<string> Names { get; } = new [] { "dumpstack" };
 
         public async Task RunAsync(IConsole console, string[] args, AnalysisSession session)
         {

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpStackCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpStackCommand.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.Tools.Analyze.Commands
 {
@@ -12,8 +14,14 @@ namespace Microsoft.Diagnostics.Tools.Analyze.Commands
         {
             foreach(var frame in session.ActiveThread.EnumerateStackTrace())
             {
-                await console.Out.WriteLineAsync($"{frame.StackPointer:x16}");
+                var methodInfo = frame.Method == null ? "<Unknown Method>" : GenerateMethodInfo(frame.Method);
+                await console.Out.WriteLineAsync($"{frame.StackPointer:x16} {frame.InstructionPointer:x16} {methodInfo}");
             }
+        }
+
+        private string GenerateMethodInfo(ClrMethod method)
+        {
+            return $"{method.Type.Name}.{method.Name}";
         }
     }
 }

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpStackCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/DumpStackCommand.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Microsoft.Diagnostics.Tools.Analyze.Commands
+{
+    public class DumpStackCommand : IAnalysisCommand
+    {
+        public IEnumerable<string> Names { get; } = new List<string>() { "dumpstack" };
+
+        public async Task RunAsync(IConsole console, string[] args, AnalysisSession session)
+        {
+            foreach(var frame in session.ActiveThread.EnumerateStackTrace())
+            {
+                await console.Out.WriteLineAsync($"{frame.StackPointer:x16}");
+            }
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/HelpCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/HelpCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 
@@ -5,7 +6,7 @@ namespace Microsoft.Diagnostics.Tools.Analyze.Commands
 {
     public class HelpCommand : IAnalysisCommand
     {
-        public string Name => "help";
+        public IEnumerable<string> Names { get; } = new List<string>() { "help" };
 
         public async Task RunAsync(IConsole console, string[] args, AnalysisSession session)
         {

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/HelpCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/HelpCommand.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Microsoft.Diagnostics.Tools.Analyze.Commands
+{
+    public class HelpCommand : IAnalysisCommand
+    {
+        public string Name => "help";
+
+        public async Task RunAsync(IConsole console, string[] args, AnalysisSession session)
+        {
+            await console.Error.WriteLineAsync("Not yet implemented");
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/IAnalysisCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/IAnalysisCommand.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Microsoft.Diagnostics.Tools.Analyze.Commands
+{
+    public interface IAnalysisCommand
+    {
+        string Name { get; }
+
+        Task RunAsync(IConsole console, string[] args, AnalysisSession session);
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/IAnalysisCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/IAnalysisCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 
@@ -5,7 +6,7 @@ namespace Microsoft.Diagnostics.Tools.Analyze.Commands
 {
     public interface IAnalysisCommand
     {
-        string Name { get; }
+        IEnumerable<string> Names { get; }
 
         Task RunAsync(IConsole console, string[] args, AnalysisSession session);
     }

--- a/src/dotnet-monitor/src/dotnet-analyze/Commands/ThreadsCommand.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Commands/ThreadsCommand.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Microsoft.Diagnostics.Tools.Analyze.Commands
+{
+    public class ThreadsCommand : IAnalysisCommand
+    {
+        public IEnumerable<string> Names { get; } = new List<string>() { "~", "threads" };
+
+        public async Task RunAsync(IConsole console, string[] args, AnalysisSession session)
+        {
+            foreach(var thread in session.Runtime.Threads)
+            {
+                var isActive = session.ActiveThreadId == thread.ManagedThreadId ? "." : " ";
+                await console.Out.WriteLineAsync($"{isActive}{thread.ManagedThreadId.ToString().PadLeft(2)} Id: {Utils.FormatAddress(thread.OSThreadId)} Teb: {Utils.FormatAddress(thread.Teb)}");
+            }
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/Program.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.Internal.Utilities;
@@ -17,50 +18,25 @@ namespace Microsoft.Diagnostics.Tools.Analyze
         [Argument(0, "<DUMP>", Description = "The path to the dump file to analyze.")]
         public string DumpPath { get; set; }
 
-        public int OnExecute(IConsole console, CommandLineApplication app)
+        public async Task<int> OnExecuteAsync(IConsole console, CommandLineApplication app)
         {
             // Load the dump
             console.WriteLine($"Loading crash dump {DumpPath}...");
             using (var target = DataTarget.LoadCrashDump(DumpPath))
             {
-                console.WriteLine("CLR Versions:");
-                foreach (var clr in target.ClrVersions)
-                {
-                    console.WriteLine($"  {GetFlavorName(clr.Flavor)}: {clr.Version}");
-                }
-
                 // Assume there's only one
                 if(target.ClrVersions.Count > 1)
                 {
-                    console.Error.WriteLine("Multiple CLR versions are present, select one to analyze with (TODO).");
+                    console.Error.WriteLine("Multiple CLR versions are present!");
                     return 1;
                 }
 
                 var runtime = target.ClrVersions[0].CreateRuntime();
 
-                // Run analyzers
-                AsyncHangAnalyzer.Run(console, runtime);
+                var session = new AnalysisSession(target, runtime);
+                await CommandProcessor.RunAsync(console, session);
             }
             return 0;
-        }
-
-        private string GetFlavorName(ClrFlavor flavor)
-        {
-#pragma warning disable 0612, 0618
-            switch (flavor)
-            {
-                case ClrFlavor.Desktop:
-                    return ".NET Framework";
-                case ClrFlavor.CoreCLR:
-                    return "Silverlight";
-                case ClrFlavor.Native:
-                    return ".NET Native";
-                case ClrFlavor.Core:
-                    return ".NET Core";
-                default:
-                    return "Unknown CLR";
-            }
-#pragma warning restore 0612, 0618
         }
 
         private static int Main(string[] args)

--- a/src/dotnet-monitor/src/dotnet-analyze/Program.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Program.cs
@@ -10,7 +10,7 @@ using Microsoft.Internal.Utilities;
 
 namespace Microsoft.Diagnostics.Tools.Analyze
 {
-    [Command(Name = "dotnet-analyze", Description = "Analyzes a crash dump for known issues")]
+    [Command(Name = "dotnet-analyze", Description = "Inspect a crash dump using interactive commands")]
     internal class Program
     {
         [FileExists(ErrorMessage = "The dump file could not be found.")]

--- a/src/dotnet-monitor/src/dotnet-analyze/TypeHeapStats.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/TypeHeapStats.cs
@@ -1,0 +1,22 @@
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Tools.Analyze
+{
+    public class TypeHeapStats
+    {
+        public ClrType Type { get; }
+        public long Count { get; private set; }
+        public ulong TotalSize { get; private set; }
+
+        public TypeHeapStats(ClrType type)
+        {
+            Type = type;
+        }
+
+        public void AddObject(ulong size)
+        {
+            Count++;
+            TotalSize += size;
+        }
+    }
+}

--- a/src/dotnet-monitor/src/dotnet-analyze/Utils.cs
+++ b/src/dotnet-monitor/src/dotnet-analyze/Utils.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.Diagnostics.Tools.Analyze
+{
+    internal static class Utils
+    {
+        internal static string FormatAddress(uint addr)
+        {
+            var hi = (short)(addr >> 16);
+            var lo = (short)addr;
+            return $"{hi:x4}`{lo:x4}";
+        }
+
+        internal static string FormatAddress(ulong addr)
+        {
+            var hi = (int)(addr >> 32);
+            var lo = (int)addr;
+            return $"{hi:x8}`{lo:x8}";
+        }
+    }
+}


### PR DESCRIPTION
An SOS-like "REPL" for exploring .NET memory dumps (based on [CLRMD](https://github.com/Microsoft/clrmd)).

```
Inspect a crash dump using interactive commands

Usage: dotnet-analyze [arguments] [options]

Arguments:
<DUMP>        The path to the dump file to analyze.

Options:
  -?|-h|--help  Show help information
```

When you launch this command, a REPL prompt is provided:

```
Loading crash dump C:\Users\anurse\Desktop\dotnet-18956-20181012-153829-088.dmp...
Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.
Type 'quit' or 'exit' to exit the analysis session.
>
```

The following commands are available:
* `quit` (alias `exit`) - Exit the tool
* `help` - List commands and help information (not yet implemented ;))
* `threads` (alias `~`) - List thread
* `DumpStack` - Dump managed stack trace for the current thread. A little like SOS's `!DumpStack`
* `DumpHeap` - Dump information about objects on the heap, grouped by type. A little like SOS's `!DumpHeap -stat`