### PR TITLE
Add profiles to dotnet-collect

### DIFF
--- a/src/DotNetDiagnostics/src/Common/CommandLineException.cs
+++ b/src/DotNetDiagnostics/src/Common/CommandLineException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Internal.Utilities
+{
+    public class CommandLineException : Exception
+    {
+        public CommandLineException()
+        {
+        }
+
+        public CommandLineException(string message) : base(message)
+        {
+        }
+
+        public CommandLineException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected CommandLineException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/DotNetDiagnostics/src/dotnet-collect/CollectionConfiguration.cs
+++ b/src/DotNetDiagnostics/src/dotnet-collect/CollectionConfiguration.cs
@@ -33,6 +33,14 @@ namespace Microsoft.Diagnostics.Tools.Collect
             return builder.ToString();
         }
 
+        public void AddProfile(CollectionProfile profile)
+        {
+            foreach (var spec in profile.EventSpecs)
+            {
+                Providers.Add(spec);
+            }
+        }
+
         private string SerializeProviders(IList<EventSpec> providers) => string.Join(",", providers.Select(s => s.ToConfigString()));
     }
 }

--- a/src/DotNetDiagnostics/src/dotnet-collect/CollectionProfile.cs
+++ b/src/DotNetDiagnostics/src/dotnet-collect/CollectionProfile.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Tools.Collect
+{
+    public class CollectionProfile
+    {
+        public static readonly string DefaultProfileName = "Default";
+
+        public string Name { get; }
+        public string Description { get; }
+        public IReadOnlyList<EventSpec> EventSpecs { get; }
+
+        public CollectionProfile(string name, string description, IEnumerable<EventSpec> eventSpecs)
+        {
+            Name = name;
+            Description = description;
+            EventSpecs = eventSpecs.ToList();
+        }
+    }
+}

--- a/src/DotNetDiagnostics/src/dotnet-collect/KnownData.cs
+++ b/src/DotNetDiagnostics/src/dotnet-collect/KnownData.cs
@@ -27,6 +27,22 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 new[] {
                     new EventSpec(ClrTraceEventParser.ProviderName, (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational)
                 });
+
+            yield return new CollectionProfile(
+                "AspNetCore",
+                "A set of event providers useful for diagnosing problems in ASP.NET Core applications.",
+                new[]
+                {
+                    new EventSpec("Microsoft-AspNetCore-Hosting", ulong.MaxValue, EventLevel.Informational),
+                });
+
+            yield return new CollectionProfile(
+                "Kestrel",
+                "Detailed events for ASP.NET Core Kestrel",
+                new[]
+                {
+                    new EventSpec("Microsoft-AspNetCore-Server-Kestrel", ulong.MaxValue, EventLevel.Verbose),
+                });
         }
 
         private static KnownProvider CreateClrProvider()

--- a/src/DotNetDiagnostics/src/dotnet-collect/KnownData.cs
+++ b/src/DotNetDiagnostics/src/dotnet-collect/KnownData.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using Microsoft.Diagnostics.Tracing.Parsers;
+
+namespace Microsoft.Diagnostics.Tools.Collect
+{
+    internal static class KnownData
+    {
+        private static readonly IReadOnlyDictionary<string, KnownProvider> _knownProviders =
+            CreateKnownProviders().ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly IReadOnlyDictionary<string, CollectionProfile> _knownProfiles =
+            CreateProfiles().ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+        private static IEnumerable<KnownProvider> CreateKnownProviders()
+        {
+            yield return CreateClrProvider();
+        }
+
+        private static IEnumerable<CollectionProfile> CreateProfiles()
+        {
+            yield return new CollectionProfile(
+                CollectionProfile.DefaultProfileName,
+                "A default set of event providers useful for diagosing problems in any .NET application.",
+                new[] {
+                    new EventSpec(ClrTraceEventParser.ProviderName, (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational)
+                });
+        }
+
+        private static KnownProvider CreateClrProvider()
+        {
+            return new KnownProvider(
+                ClrTraceEventParser.ProviderName,
+                ClrTraceEventParser.ProviderGuid,
+                ScanKeywordType(typeof(ClrTraceEventParser.Keywords)));
+        }
+
+        public static IReadOnlyList<CollectionProfile> GetAllProfiles() => _knownProfiles.Values.ToList();
+        public static IReadOnlyList<KnownProvider> GetAllProviders() => _knownProviders.Values.ToList();
+
+        public static bool TryGetProvider(string providerName, out KnownProvider provider) => _knownProviders.TryGetValue(providerName, out provider);
+        public static bool TryGetProfile(string profileName, out CollectionProfile profile) => _knownProfiles.TryGetValue(profileName, out profile);
+
+        private static IEnumerable<KnownKeyword> ScanKeywordType(Type keywordType)
+        {
+            var values = Enum.GetValues(keywordType).Cast<long>().ToList();
+            var keywords = values.Distinct().Select(v => new KnownKeyword(Enum.GetName(keywordType, v), (ulong)v)).ToList();
+            return keywords;
+        }
+    }
+
+    internal class KnownProvider
+    {
+        public string Name { get; }
+        public Guid Guid { get; }
+        public IReadOnlyDictionary<string, KnownKeyword> Keywords { get; }
+
+        public KnownProvider(string name, Guid guid, IEnumerable<KnownKeyword> keywords)
+        {
+            Name = name;
+            Guid = guid;
+            Keywords = keywords.ToDictionary(k => k.Name, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    internal class KnownKeyword
+    {
+        public string Name { get; }
+        public ulong Value { get; }
+
+        public KnownKeyword(string name, ulong value)
+        {
+            Name = name;
+            Value = value;
+        }
+    }
+}

--- a/src/DotNetDiagnostics/src/dotnet-collect/Program.cs
+++ b/src/DotNetDiagnostics/src/dotnet-collect/Program.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Diagnostics.Tools.Collect
         [Option("--list-profiles", Description = "Gets a list of predefined collection profiles.")]
         public bool ListProfiles { get; set; }
 
+        [Option("--no-default", Description = "Don't enable the default profile.")]
+        public bool NoDefault { get; set; }
+
         public async Task<int> OnExecuteAsync(IConsole console, CommandLineApplication app)
         {
             if (ListProfiles)
@@ -85,7 +88,7 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 }
             }
 
-            if (config.Providers.Count == 0)
+            if (!NoDefault)
             {
                 // Enable the default profile if nothing is specified
                 if (!KnownData.TryGetProfile(CollectionProfile.DefaultProfileName, out var defaultProfile))

--- a/src/DotNetDiagnostics/src/dotnet-collect/dotnet-collect.csproj
+++ b/src/DotNetDiagnostics/src/dotnet-collect/dotnet-collect.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\CommandLineException.cs" Link="CommandLineException.cs" />
     <Compile Include="..\Common\ConsoleCancellation.cs" Link="ConsoleCancellation.cs" />
     <Compile Include="..\Common\DebugUtil.cs" Link="DebugUtil.cs" />
   </ItemGroup>


### PR DESCRIPTION
Adds support for some predefined named profiles of useful events. Also `dotnet-collect` now has a "default" profile that enables useful .NET events even if no arguments are specified.