### PR TITLE
Set the MINIDUMP_TYPE enum values correctly

### DIFF
--- a/src/DotNetDiagnostics/src/dotnet-dump/Dumper.Windows.cs
+++ b/src/DotNetDiagnostics/src/dotnet-dump/Dumper.Windows.cs
@@ -43,33 +43,34 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     public int ClientPointers;
                 }
 
+                [Flags]
                 public enum MINIDUMP_TYPE : uint
                 {
-                    MiniDumpNormal,
-                    MiniDumpWithDataSegs,
-                    MiniDumpWithFullMemory,
-                    MiniDumpWithHandleData,
-                    MiniDumpFilterMemory,
-                    MiniDumpScanMemory,
-                    MiniDumpWithUnloadedModules,
-                    MiniDumpWithIndirectlyReferencedMemory,
-                    MiniDumpFilterModulePaths,
-                    MiniDumpWithProcessThreadData,
-                    MiniDumpWithPrivateReadWriteMemory,
-                    MiniDumpWithoutOptionalData,
-                    MiniDumpWithFullMemoryInfo,
-                    MiniDumpWithThreadInfo,
-                    MiniDumpWithCodeSegs,
-                    MiniDumpWithoutAuxiliaryState,
-                    MiniDumpWithFullAuxiliaryState,
-                    MiniDumpWithPrivateWriteCopyMemory,
-                    MiniDumpIgnoreInaccessibleMemory,
-                    MiniDumpWithTokenInformation,
-                    MiniDumpWithModuleHeaders,
-                    MiniDumpFilterTriage,
-                    MiniDumpWithAvxXStateContext,
-                    MiniDumpWithIptTrace,
-                    MiniDumpValidTypeFlags
+                    MiniDumpNormal                         = 0,
+                    MiniDumpWithDataSegs                   = 1 << 0,
+                    MiniDumpWithFullMemory                 = 1 << 1,
+                    MiniDumpWithHandleData                 = 1 << 2,
+                    MiniDumpFilterMemory                   = 1 << 3,
+                    MiniDumpScanMemory                     = 1 << 4,
+                    MiniDumpWithUnloadedModules            = 1 << 5,
+                    MiniDumpWithIndirectlyReferencedMemory = 1 << 6,
+                    MiniDumpFilterModulePaths              = 1 << 7,
+                    MiniDumpWithProcessThreadData          = 1 << 8,
+                    MiniDumpWithPrivateReadWriteMemory     = 1 << 9,
+                    MiniDumpWithoutOptionalData            = 1 << 10,
+                    MiniDumpWithFullMemoryInfo             = 1 << 11,
+                    MiniDumpWithThreadInfo                 = 1 << 12,
+                    MiniDumpWithCodeSegs                   = 1 << 13,
+                    MiniDumpWithoutAuxiliaryState          = 1 << 14,
+                    MiniDumpWithFullAuxiliaryState         = 1 << 15,
+                    MiniDumpWithPrivateWriteCopyMemory     = 1 << 16,
+                    MiniDumpIgnoreInaccessibleMemory       = 1 << 17,
+                    MiniDumpWithTokenInformation           = 1 << 18,
+                    MiniDumpWithModuleHeaders              = 1 << 19,
+                    MiniDumpFilterTriage                   = 1 << 20,
+                    MiniDumpWithAvxXStateContext           = 1 << 21,
+                    MiniDumpWithIptTrace                   = 1 << 22,
+                    MiniDumpValidTypeFlags                 = (-1) ^ ((~1) << 22)
                 }
             }
         }


### PR DESCRIPTION
Decorate the MINIDUMP_TYPE enum with the Flags attribute
Set the values of the MINIDUMP_TYPE enum to those found in minidumpapiset.h file from the Windows 10 SDK