### PR TITLE
add feed and install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ AspLabs
 
 Repo for ASP.NET experiments that are not ready for a production release.
 
+Projects:
+* [.NET Diagnostics tools](./src/DotNetDiagnostics/)
+* [Http Client REPL](./src/HttpRepl/)
+* [Proxy Middleware](./src/Proxy/)
+* [WebHooks](./src/WebHooks/)
+
 ## Building
 
 To build this repo, run the `build.cmd` or `build.sh` in the root of this repo. This repo uses the .NET [Arcade toolset](https://github.com/dotnet/arcade).

--- a/src/DotNetDiagnostics/README.md
+++ b/src/DotNetDiagnostics/README.md
@@ -2,6 +2,18 @@
 
 This repository contains tools for collecting diagnostics from .NET applications.
 
+Nightly builds of these tools are available on https://dotnet.myget.org/gallery/aspnetcore-dev. To install, use one of the following command lines:
+
+* `dotnet tool install -g dotnet-dump --add-source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json --version [version]`
+* `dotnet tool install -g dotnet-collect --add-source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json --version [version]`
+* `dotnet tool install -g dotnet-analyze --add-source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json --version [version]`
+
+You **must** specify an exact version to install. You can find the latest versions of these packages at https://dotnet.myget.org/gallery/aspnetcore-dev . They are also listed below:
+
+* `dotnet-collect`: ![dotnet-collect](https://img.shields.io/dotnet.myget/aspnetcore-dev/v/dotnet-collect.svg)
+* `dotnet-dump`: ![dotnet-dump](https://img.shields.io/dotnet.myget/aspnetcore-dev/v/dotnet-dump.svg)
+* `dotnet-analyze`: ![dotnet-analyze](https://img.shields.io/dotnet.myget/aspnetcore-dev/v/dotnet-analyze.svg)
+
 ## [dotnet-dump](src/dotnet-dump)
 
 A cross-platform tool to collect memory dumps of .NET processes:
@@ -51,7 +63,7 @@ Options:
 
 ## [dotnet-analyze](src/dotnet-analyze)
 
-An SOS-like "REPL" for exploring .NET memory dumps (based on [CLRMD](https://github.com/Microsoft/clrmd)).
+An SOS-like "REPL" for exploring .NET memory dumps (based on [CLRMD](https://github.com/Microsoft/clrmd)) as well as `.netperf` event traces collected by `dotnet-collect`.
 
 ```
 Inspect a crash dump using interactive commands


### PR DESCRIPTION
Now that we're publishing to a MyGet feed (`aspnetcore-dev` for now), included instructions on how to install the prototype tools.