### PR TITLE
Fixing the PreReleaseVersionLabel  condition

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,5 +8,6 @@
     <MajorVersion>0</MajorVersion>
     <MinorVersion>1</MinorVersion>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel Condition="'$(MSBuildProjectName)' == 'Microsoft.HttpRepl'">preview</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>

--- a/src/HttpRepl/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/HttpRepl/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Verified that this works correctly by setting $ci to true and $OfficialBuildId to valid build number. It created the repl with right package version and other packages were still in alpha.