### PR TITLE
Fix a null reference exception that occurs when calling up completion…

### DIFF
--- a/src/HttpRepl/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/HttpRepl/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -195,7 +195,12 @@ namespace Microsoft.HttpRepl.Commands
                     if (continuationParseResult.SelectedSection == 0)
                     {
                         string normalizedCompletionText = continuationParseResult.Sections[0].Substring(0, continuationParseResult.CaretPositionWithinSelectedSection);
-                        suggestions.UnionWith(ServerPathCompletion.GetCompletions(programState, normalizedCompletionText));
+                        IEnumerable<string> completions = ServerPathCompletion.GetCompletions(programState, normalizedCompletionText);
+
+                        if (completions != null)
+                        {
+                            suggestions.UnionWith(completions);
+                        }
                     }
 
                     return suggestions.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();


### PR DESCRIPTION
…s when the swagger endpoint isn't yet set