### PR TITLE
Copy sources from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,5 +5,9 @@
     <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="anurse-clrmd" value="https://www.myget.org/F/anurse-clrmd/api/v3/index.json" />
+    <!-- aspnetcore-dev feed for internal packages like Microsoft.Extensions.Logging.Testing -->
+    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
**TL;DR**

We need that all restore sources are located in `NuGet.config` since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)