### PR TITLE
Fix the build by removing async using

### DIFF
--- a/src/Proxy/src/ProxyAdvancedExtensions.cs
+++ b/src/Proxy/src/ProxyAdvancedExtensions.cs
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Proxy
             // SendAsync removes chunking from the response. This removes the header so it doesn't expect a chunked response.
             response.Headers.Remove("transfer-encoding");
 
-            await using var responseStream = await responseMessage.Content.ReadAsStreamAsync();
+            using var responseStream = await responseMessage.Content.ReadAsStreamAsync();
             await responseStream.CopyToAsync(response.Body, StreamCopyBufferSize, context.RequestAborted);
         }
     }


### PR DESCRIPTION
Reverts https://github.com/aspnet/AspLabs/pull/290 to fix the build.

It looks like IAsyncDisposable isn't available in netstandard2.0.