### PR TITLE
Add a ProxyProtocol sample

### DIFF
--- a/src/ProxyProtocol/Client.Sample/Client.Sample.csproj
+++ b/src/ProxyProtocol/Client.Sample/Client.Sample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/ProxyProtocol/Client.Sample/Program.cs
+++ b/src/ProxyProtocol/Client.Sample/Program.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Client.Sample
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var serverAddress = new Uri("https://localhost:5001");
+
+            Console.WriteLine("Ready");
+            Console.ReadKey();
+
+            await ConnectAsync(serverAddress);
+        }
+
+        private static async Task ConnectAsync(Uri serverAddress)
+        {
+            using var client = new TcpClient();
+            Console.WriteLine($"Connecting to {serverAddress}");
+            await client.ConnectAsync(serverAddress.Host, serverAddress.Port);
+
+            Stream stream = client.GetStream();
+
+            if (serverAddress.Scheme == Uri.UriSchemeHttps)
+            {
+                Console.WriteLine("Negotiating TLS");
+                var sslStream = new SslStream(stream);
+                await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
+                {
+                    TargetHost = serverAddress.Host,
+                    RemoteCertificateValidationCallback = (_, __, ___, ____) => true,
+                });
+
+                stream = sslStream;
+            }
+
+            Console.WriteLine("Sending message");
+            var data = CreateMessage(serverAddress);
+            await stream.WriteAsync(data);
+
+            Console.WriteLine("Reading response");
+            using var reader = new StreamReader(stream);
+            var response = await reader.ReadToEndAsync();
+
+            Console.WriteLine(response);
+
+            stream.Dispose();
+        }
+
+        /// Proxy Protocol v2: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt Section 2.2
+        private static byte[] CreateMessage(Uri serverAddress)
+        {
+            var memoryStream = new MemoryStream();
+            var prefix = new byte[] {
+                // Preamble(12 bytes) : 0D-0A-0D-0A-00-0D-0A-51-55-49-54-0A
+                0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
+                //  -21 Version + stream
+                0x21,
+                //  -11 TCP over IPv4
+                0x11,
+                //  -00-14 length
+                0x00, 0x14,
+                //  -AC-1C-00-04 src address
+                0xAC, 0x1C, 0x00, 0x04,
+                //  -01-02-03-04 dest address
+                0x01, 0x02, 0x03, 0x04,
+                //  -D7-9A src port
+                0xD7, 0x9A,
+                //  -13-88 dest port
+                0x13, 0x88,
+                //  -EE PP2_TYPE_AZURE
+                0xEE,
+                //  -00-05 length
+                0x00, 0x05,
+                //  -01 LINKID type
+                0x01,
+                //  -33-00-00-26 LINKID
+                0x33, 0x00, 0x00, 0x26
+            };
+            memoryStream.Write(prefix);
+
+            var request = $"GET / HTTP/1.1\r\nHost: {serverAddress.Host}\r\nConnection: close\r\n\r\n";
+            memoryStream.Write(Encoding.ASCII.GetBytes(request));
+
+            return memoryStream.ToArray();
+        }
+    }
+}

--- a/src/ProxyProtocol/Client.Sample/Program.cs
+++ b/src/ProxyProtocol/Client.Sample/Program.cs
@@ -1,8 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Reflection.Metadata;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,15 +14,17 @@ namespace Client.Sample
     {
         static async Task Main(string[] args)
         {
-            var serverAddress = new Uri("https://localhost:5001");
+            var serverAddress =
+                new Uri("https://localhost:5001");
+                // new Uri("http://localhost:5000");
 
-            Console.WriteLine("Ready");
+            Console.WriteLine("Ready, press any key to run.");
             Console.ReadKey();
 
-            await ConnectAsync(serverAddress);
+            await SendRequestAsync(serverAddress);
         }
 
-        private static async Task ConnectAsync(Uri serverAddress)
+        private static async Task SendRequestAsync(Uri serverAddress)
         {
             using var client = new TcpClient();
             Console.WriteLine($"Connecting to {serverAddress}");
@@ -35,7 +39,6 @@ namespace Client.Sample
                 await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
                 {
                     TargetHost = serverAddress.Host,
-                    RemoteCertificateValidationCallback = (_, __, ___, ____) => true,
                 });
 
                 stream = sslStream;
@@ -43,11 +46,12 @@ namespace Client.Sample
 
             Console.WriteLine("Sending message");
             var data = CreateMessage(serverAddress);
+            // Send it one byte at a time to test boundary conditions.
             for (var i = 0; i < data.Length; i++)
             {
                 Console.Write(".");
-                await stream.WriteAsync(data, i, 1);
-                await Task.Delay(TimeSpan.FromSeconds(0.1));
+                await stream.WriteAsync(data.AsMemory(i, 1));
+                await Task.Delay(TimeSpan.FromSeconds(0.05));
             }
             Console.WriteLine();
 

--- a/src/ProxyProtocol/Client.Sample/Program.cs
+++ b/src/ProxyProtocol/Client.Sample/Program.cs
@@ -43,7 +43,13 @@ namespace Client.Sample
 
             Console.WriteLine("Sending message");
             var data = CreateMessage(serverAddress);
-            await stream.WriteAsync(data);
+            for (var i = 0; i < data.Length; i++)
+            {
+                Console.Write(".");
+                await stream.WriteAsync(data, i, 1);
+                await Task.Delay(TimeSpan.FromSeconds(0.1));
+            }
+            Console.WriteLine();
 
             Console.WriteLine("Reading response");
             using var reader = new StreamReader(stream);

--- a/src/ProxyProtocol/ProxyProtocol.Sample/Program.cs
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/Program.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ProxyProtocol.Sample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.ConfigureKestrel((context, options) =>
+                    {
+                        var logger = options.ApplicationServices.GetRequiredService<ILogger<Program>>();
+                        options.ListenAnyIP(5001, listenOptions =>
+                        {
+                            listenOptions.UseHttps();
+                            listenOptions.Use(async (connectionContext, next) =>
+                            {
+                                await ProxyProtocol.ProcessAsync(connectionContext, next, logger);
+                            });
+                        });
+                    });
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/ProxyProtocol/ProxyProtocol.Sample/Program.cs
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +26,13 @@ namespace ProxyProtocol.Sample
                         options.ListenAnyIP(5001, listenOptions =>
                         {
                             listenOptions.UseHttps();
+                            listenOptions.Use(async (connectionContext, next) =>
+                            {
+                                await ProxyProtocol.ProcessAsync(connectionContext, next, logger);
+                            });
+                        });
+                        options.ListenAnyIP(5000, listenOptions =>
+                        {
                             listenOptions.Use(async (connectionContext, next) =>
                             {
                                 await ProxyProtocol.ProcessAsync(connectionContext, next, logger);

--- a/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.Sample.csproj
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.Sample.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
+  </ItemGroup>
+  
+</Project>

--- a/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.Sample.csproj
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.Sample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.cs
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+
+namespace ProxyProtocol.Sample
+{
+    public static class ProxyProtocol
+    {
+        // The proxy protocol marker.
+        private static readonly byte[] Preamble = { 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A };
+        public static readonly string SourceIPAddressKey = "ProxyProtocolV2SourceIPAddress";
+        public static readonly string DestinationIPAddressKey = "ProxyProtocolV2DestinationIPAddress";
+        public static readonly string SourcePortKey = "ProxyProtocolV2SourcePort";
+        public static readonly string DestinationPortKey = "ProxyProtocolV2DestinationPort";
+        public static readonly string LinkIdKey = "ProxyProtocolV2LinkId";
+
+        /// <summary>
+        /// Proxy Protocol v2: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt Section 2.2
+        /// Preamble(12 bytes) : 0D-0A-0D-0A-00-0D-0A-51-55-49-54-0A
+        ///  -21                        Version + stream    12
+        ///  -11                        TCP over IPv4       13
+        ///  -00-14                     length              14
+        ///  -AC-1C-00-04               src address         16
+        ///  -01-02-03-04               dest address        20
+        ///  -D7-9A                     src port            24
+        ///  -13-88                     dest port           26
+        ///  -EE                        PP2_TYPE_AZURE      28
+        ///  -00-05                     length              29
+        ///  -01                        LINKID type         31
+        ///  -33-00-00-26               LINKID              32.
+        /// </summary>
+        public static async Task ProcessAsync(ConnectionContext connectionContext, Func<Task> next, ILogger logger = null)
+        {
+            var input = connectionContext.Transport.Input;
+            while (true)
+            {
+                var result = await input.ReadAsync();
+                var buffer = result.Buffer;
+
+                try
+                {
+                    if (result.IsCompleted)
+                    {
+                        return;
+                    }
+
+                    // Buffer does not have enough data to make decision
+                    if (buffer.Length < 12)
+                    {
+                        continue;
+                    }
+
+                    var bufferArray = buffer.ToArray();
+                    if (!IsProxyProtocol(bufferArray))
+                    {
+                        // Break if it is not PPv2.
+                        break;
+                    }
+                    else
+                    {
+                        if (HasEnoughPpv2Data(bufferArray))
+                        {
+                            ExtractPpv2Data(ref buffer, bufferArray, connectionContext, logger);
+
+                            // It is PPv2, and we have enough data for PPv2
+                            break;
+                        }
+
+                        // It is PPv2, and we don't have enough data for PPv2
+                    }
+                }
+                finally
+                {
+                    input.AdvanceTo(buffer.Start);
+                }
+            }
+
+            await next();
+        }
+
+        private static bool IsProxyProtocol(byte[] buffer)
+        {
+            if (buffer.Length > 12)
+            {
+                for (var i = 0; i < 12; i++)
+                {
+                    if (Preamble[i] != buffer[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void ExtractPpv2Data(ref ReadOnlySequence<byte> buffer, byte[] bufferArray, ConnectionContext context, ILogger logger = null)
+        {
+            // Probe traffic does not have valid ppv2 data.
+            try
+            {
+                var length = (short)(bufferArray[15] | (bufferArray[14] << 8));
+                var srcIpAddressArray = new byte[4];
+                Array.Copy(bufferArray, 16, srcIpAddressArray, 0, 4);
+                var srcAddress = new IPAddress(srcIpAddressArray);
+
+                var destIpAddressArray = new byte[4];
+                Array.Copy(bufferArray, 20, destIpAddressArray, 0, 4);
+                var destAddress = new IPAddress(destIpAddressArray);
+
+                var srcPort = (int)(bufferArray[25] | (bufferArray[24] << 8));
+                var destPort = (int)(bufferArray[27] | (bufferArray[26] << 8));
+
+                context.Items.Add(SourceIPAddressKey, srcAddress);
+                context.Items.Add(DestinationIPAddressKey, destAddress);
+                context.Items.Add(SourcePortKey, srcPort);
+                context.Items.Add(DestinationPortKey, destPort);
+
+                // Probe traffic does not have link ids.
+                if (length > 12)
+                {
+                    var linkId = (long)(bufferArray[32] | (bufferArray[33] << 8) | (bufferArray[34] << 16) |
+                                         (bufferArray[35] << 24));
+
+                    context.Items.Add(LinkIdKey, linkId.ToString());
+                }
+
+                // Trim the buffer so the HTTP parser can pick up from there.
+                buffer = buffer.Slice(length + 16);
+            }
+            catch
+            {
+                logger?.LogInformation($"ExtractPpv2Data error. BufferArray: {BitConverter.ToString(bufferArray)}");
+                throw;
+            }
+        }
+
+        private static bool HasEnoughPpv2Data(IReadOnlyList<byte> bufferArray)
+        {
+            if (bufferArray.Count < 16)
+            {
+                return false;
+            }
+
+            var length = (short)(bufferArray[15] | (bufferArray[14] << 8));
+            return bufferArray.Count >= 16 + length;
+        }
+    }
+}

--- a/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocolFeature.cs
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocolFeature.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
+
+namespace ProxyProtocol.Sample
+{
+    public class ProxyProtocolFeature
+    {
+        public IPAddress SourceIp { get; internal set; }
+        public IPAddress DestinationIp { get; internal set; }
+        public int SourcePort { get; internal set; }
+        public int DestinationPort { get; internal set; }
+        public long LinkId { get; internal set; }
+    }
+}

--- a/src/ProxyProtocol/ProxyProtocol.Sample/Startup.cs
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/Startup.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ProxyProtocol.Sample
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    var connectionItems = context.Features.Get<IConnectionItemsFeature>()?.Items;
+                    if (connectionItems == null)
+                    {
+                        await context.Response.WriteAsync("Unable to access the connection items. Are you using Kestrel?");
+                        return;
+                    }
+
+                    await context.Response.WriteAsync($"Source IP: {connectionItems[ProxyProtocol.SourceIPAddressKey]}\r\n");
+                    await context.Response.WriteAsync($"Destination IP: {connectionItems[ProxyProtocol.DestinationIPAddressKey]}\r\n");
+                    await context.Response.WriteAsync($"Source Port: {connectionItems[ProxyProtocol.SourcePortKey]}\r\n");
+                    await context.Response.WriteAsync($"Destination Port: {connectionItems[ProxyProtocol.DestinationPortKey]}\r\n");
+                    await context.Response.WriteAsync($"Link Id: {connectionItems[ProxyProtocol.LinkIdKey]}\r\n");
+                });
+            });
+        }
+    }
+}

--- a/src/ProxyProtocol/ProxyProtocol.Sample/Startup.cs
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/Startup.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,18 +31,18 @@ namespace ProxyProtocol.Sample
             {
                 endpoints.MapGet("/", async context =>
                 {
-                    var connectionItems = context.Features.Get<IConnectionItemsFeature>()?.Items;
-                    if (connectionItems == null)
+                    var proxyFeature = context.Features.Get<ProxyProtocolFeature>();
+                    if (proxyFeature == null)
                     {
-                        await context.Response.WriteAsync("Unable to access the connection items. Are you using Kestrel?");
+                        await context.Response.WriteAsync("Unable to access the proxy protocol feature. Did the client send that data?");
                         return;
                     }
 
-                    await context.Response.WriteAsync($"Source IP: {connectionItems[ProxyProtocol.SourceIPAddressKey]}\r\n");
-                    await context.Response.WriteAsync($"Destination IP: {connectionItems[ProxyProtocol.DestinationIPAddressKey]}\r\n");
-                    await context.Response.WriteAsync($"Source Port: {connectionItems[ProxyProtocol.SourcePortKey]}\r\n");
-                    await context.Response.WriteAsync($"Destination Port: {connectionItems[ProxyProtocol.DestinationPortKey]}\r\n");
-                    await context.Response.WriteAsync($"Link Id: {connectionItems[ProxyProtocol.LinkIdKey]}\r\n");
+                    await context.Response.WriteAsync($"Source IP: {proxyFeature.SourceIp}\r\n");
+                    await context.Response.WriteAsync($"Destination IP: {proxyFeature.DestinationIp}\r\n");
+                    await context.Response.WriteAsync($"Source Port: {proxyFeature.SourcePort}\r\n");
+                    await context.Response.WriteAsync($"Destination Port: {proxyFeature.DestinationPort}\r\n");
+                    await context.Response.WriteAsync($"Link Id: {proxyFeature.LinkId}\r\n");
                 });
             });
         }

--- a/src/ProxyProtocol/ProxyProtocol.Sample/appsettings.Development.json
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Debug",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/ProxyProtocol/ProxyProtocol.Sample/appsettings.json
+++ b/src/ProxyProtocol/ProxyProtocol.Sample/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/ProxyProtocol/ProxyProtocol.sln
+++ b/src/ProxyProtocol/ProxyProtocol.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.128
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProxyProtocol.Sample", "ProxyProtocol.Sample\ProxyProtocol.Sample.csproj", "{BA5300BC-7822-4DBC-B342-4C1FD571B1A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client.Sample", "Client.Sample\Client.Sample.csproj", "{9CB46DAE-BCDB-4E12-952E-AF79224D56D7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BA5300BC-7822-4DBC-B342-4C1FD571B1A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA5300BC-7822-4DBC-B342-4C1FD571B1A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA5300BC-7822-4DBC-B342-4C1FD571B1A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA5300BC-7822-4DBC-B342-4C1FD571B1A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CB46DAE-BCDB-4E12-952E-AF79224D56D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CB46DAE-BCDB-4E12-952E-AF79224D56D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CB46DAE-BCDB-4E12-952E-AF79224D56D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CB46DAE-BCDB-4E12-952E-AF79224D56D7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C594949-18F3-49BB-9161-3A248D826E6D}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This is a sample for parsing the Proxy Protocol as a Kestrel connection middleware. The protocol allows level 4 proxies to forward information as a connection preface. The preface needs to be removed before HTTP parsing can happen.

We're publishing this to labs because multiple parties have expressed interest in it. We know it's not exhaustive, it (e.g. it only handles IPv4 addresses), but it's a good starting point for interested parties.

See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt Section 2.2

Azure private link is one such proxy that sends this data:
https://docs.microsoft.com/en-us/azure/private-link/private-link-service-overview#properties (EnableProxyProtocol)

Ngnix has a first class implementation of this spec (inbound). https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/#configuring-nginx-to-accept-the-proxy-protocol
