### PR TITLE
Update IDataContractResolver to ISerializerDataContractResolver in Sw…

### DIFF
--- a/src/GrpcHttpApi/dependencies.props
+++ b/src/GrpcHttpApi/dependencies.props
@@ -10,6 +10,6 @@
     <GrpcCorePackageVersion>2.29.0</GrpcCorePackageVersion>
     <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.13.0</NUnit3TestAdapterPackageVersion>
-    <SwashbuckleAspNetCorePackageVersion>5.3.1</SwashbuckleAspNetCorePackageVersion>
+    <SwashbuckleAspNetCorePackageVersion>5.6.3</SwashbuckleAspNetCorePackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/GrpcSwaggerServiceExtensions.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/GrpcSwaggerServiceExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             // Add or replace contract resolver.
-            services.Replace(ServiceDescriptor.Transient<IDataContractResolver>(s =>
+            services.Replace(ServiceDescriptor.Transient<ISerializerDataContractResolver>(s =>
             {
                 var serializerOptions = s.GetService<IOptions<JsonOptions>>()?.Value?.JsonSerializerOptions ?? new JsonSerializerOptions();
                 var innerContractResolver = new JsonSerializerDataContractResolver(serializerOptions);

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/SchemaGeneratorIntegrationTests.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/SchemaGeneratorIntegrationTests.cs
@@ -106,9 +106,10 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Tests
         public void GenerateSchema_Struct_ReturnSchema()
         {
             // Arrange & Act
-            var (schema, _) = GenerateSchema(typeof(Struct));
+            var (schema, repository) = GenerateSchema(typeof(Struct));
 
             // Assert
+            schema = repository.Schemas[schema.Reference.Id];
             Assert.Equal("object", schema.Type);
             Assert.Equal(0, schema.Properties.Count);
             Assert.NotNull(schema.AdditionalProperties);


### PR DESCRIPTION
In Swashbuckle 5.6.3, `IDataContractResolver` was replaced with `ISerializerDataContractResolver`. 