### PR TITLE
Update GrpcHttpApi swagger version

### DIFF
--- a/src/GrpcHttpApi/dependencies.props
+++ b/src/GrpcHttpApi/dependencies.props
@@ -10,6 +10,6 @@
     <GrpcCorePackageVersion>2.33.1</GrpcCorePackageVersion>
     <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.13.0</NUnit3TestAdapterPackageVersion>
-    <SwashbuckleAspNetCorePackageVersion>5.6.3</SwashbuckleAspNetCorePackageVersion>
+    <SwashbuckleAspNetCorePackageVersion>6.1.4</SwashbuckleAspNetCorePackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcDataContractResolver.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcDataContractResolver.cs
@@ -54,7 +54,12 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal
                 if (_enumTypeMapping.TryGetValue(type, out var enumDescriptor))
                 {
                     var values = enumDescriptor.Values.Select(v => v.Name).ToList();
-                    return DataContract.ForPrimitive(type, DataType.String, dataFormat: null, enumValues: values);
+                    return DataContract.ForPrimitive(type, DataType.String, dataFormat: null, value =>
+                    {
+                        var match = enumDescriptor.Values.SingleOrDefault(v => v.Number == (int)value);
+                        var name = match?.Name ?? value.ToString();
+                        return @"""" + name + @"""";
+                    });
                 }
             }
 


### PR DESCRIPTION
Build GrpcHttpApi swagger support against latest NuGet to react to breaking change. Also using stop obsolete ForPrimative overload.