### PR TITLE
Fix Swashbuckle registration in 'api' template

### DIFF
--- a/src/ApiTemplate/templates/ApiTemplate/Properties/OpenApi.cs
+++ b/src/ApiTemplate/templates/ApiTemplate/Properties/OpenApi.cs
@@ -1,24 +1,19 @@
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.OpenApi.Models;
 
-[assembly:HostingStartup(typeof(OpenApiConfiguration))]
+[assembly: HostingStartup(typeof(OpenApiConfiguration))]
 
 public class OpenApiConfiguration : IHostingStartup, IStartupFilter
 {
     private static readonly string Version = "v1";
-    private static readonly string DocumentName = "openapi.json";
+    private static readonly string DocumentPath = "openapi.json";
     private static readonly string UIPath = "docs";
 
     public void Configure(IWebHostBuilder builder)
     {
         builder.ConfigureServices((context, services) =>
         {
-            services.AddEndpointsApiExplorer();
-            services.AddSwaggerGen(options =>
-            {
-                options.SwaggerDoc(DocumentName, new OpenApiInfo { Title = context.HostingEnvironment.ApplicationName, Version = Version });
-            });
-            services.AddTransient<IStartupFilter, OpenApiConfiguration>();
+            AddSwashbuckle(services, context.HostingEnvironment);
         });
     }
 
@@ -26,36 +21,51 @@ public class OpenApiConfiguration : IHostingStartup, IStartupFilter
     {
         return app =>
         {
-            next(app);
             ConfigureSwashbuckle(app);
+            next(app);
         };
     }
 
-    private void ConfigureSwashbuckle(IApplicationBuilder app)
+    internal static void AddSwashbuckle(IServiceCollection services, IWebHostEnvironment hostingEnvironment)
     {
-        var env = app.ApplicationServices.GetRequiredService<IHostEnvironment>();
-
-        if (env.IsDevelopment())
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(options =>
         {
-            // Fixup for Swashbuckle RoutePrefix issue
-            var rewriterOptions = new RewriteOptions();
+            options.SwaggerDoc(name: Version, info: new OpenApiInfo { Title = hostingEnvironment.ApplicationName, Version = Version });
+        });
+        services.AddTransient<IStartupFilter, OpenApiConfiguration>();
+    }
+
+    internal static void ConfigureSwashbuckle(IApplicationBuilder app)
+    {
+        var hostingEnvironment = app.ApplicationServices.GetRequiredService<IHostEnvironment>();
+
+        var rewriterOptions = new RewriteOptions();
+        if (hostingEnvironment.IsDevelopment())
+        {
+            // Configure rules for Swagger UI
             // redirect from 'docs' to 'docs/'
             rewriterOptions.AddRedirect($"^{UIPath}$", $"{UIPath}/");
             // rewrite 'docs/' to 'docs/index.html'
-            rewriterOptions.AddRewrite($"^{UIPath}/$", $"{UIPath}/index.html", skipRemainingRules: true);
-            app.UseRewriter(rewriterOptions);
+            rewriterOptions.AddRewrite($"^{UIPath}/$", $"{UIPath}/index.html", skipRemainingRules: false);
+            // rewrite 'docs/*' to 'swagger/*'
+            rewriterOptions.AddRewrite($"^{UIPath}/(.+)$", $"swagger/$1", skipRemainingRules: true);
+        }
+        // Configure rules for Swagger docs
+        // rewrite 'openapi.json' to 'swagger/{Version}/swagger.json'
+        rewriterOptions.AddRewrite($"^{DocumentPath}$", $"swagger/{Version}/swagger.json", skipRemainingRules: true);
+        app.UseRewriter(rewriterOptions);
 
+        app.UseSwagger();
+
+        if (hostingEnvironment.IsDevelopment())
+        {
             app.UseSwaggerUI(options =>
             {
-                options.SwaggerEndpoint($"/{DocumentName}", $"{env.ApplicationName} {Version}");
-                options.RoutePrefix = UIPath;
+                // NOTE: The leading slash is *very* important in the document path below as the JS served
+                //       attempts to workaround a relative path issue that breaks the UI without it
+                options.SwaggerEndpoint($"/{DocumentPath}", $"{hostingEnvironment.ApplicationName} {Version}");
             });
         }
-
-        // This has to be last as the route template is SUPER greedy (it matches '/anything')
-        app.UseSwagger(options =>
-        {
-            options.RouteTemplate = "/{documentName}";
-        });
     }
 }


### PR DESCRIPTION
- Fix issue with RoutePrefix and ordering by using rewriter to map the desired paths to the default Swashbuckle paths
- Configure Swagger UI with the desired document path (/openapi.json) so the UI shows a link to that path