### PR TITLE
Fix parsing enums from http request to its protobuf versions

### DIFF
--- a/src/GrpcHttpApi/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/GrpcHttpApi/src/Shared/ServiceDescriptorHelpers.cs
@@ -116,13 +116,17 @@ namespace Grpc.Shared.HttpApi
                     {
                         if (value is string s)
                         {
-                            var enumValueDescriptor = descriptor.EnumType.FindValueByName(s);
-                            if (enumValueDescriptor == null)
+                            if (int.TryParse(s, out int i))
                             {
-                                throw new InvalidOperationException($"Invalid enum value '{s}' for enum type {descriptor.EnumType.Name}.");
-                            }
+                                var enumValueDescriptor = descriptor.EnumType.FindValueByNumber(i);
+                                if (enumValueDescriptor == null)
+                                {
+                                    throw new InvalidOperationException($"Invalid enum value '{s}' for enum type {descriptor.EnumType.Name}.");
+                                }
 
-                            return enumValueDescriptor.Number;
+                                return enumValueDescriptor.Number;
+                            }
+                            throw new InvalidOperationException($"Enum value '{s}' is not Integer");
                         }
                         throw new InvalidOperationException("String required to convert to enum.");
                     }


### PR DESCRIPTION
I ran into a bug when converting enums from http request to protobuf. When trying to call a method from swagger containing enums in params, web api threw an exception ```InvalidOperationException: Invalid enum value '0' for enum type EnumName.```. The problem was that a comparison was performed by a string name when a number went into request.