### PR TITLE
Allow spaces in outputpath

### DIFF
--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <MakeDir Directories="$(_ClientAssetsOutputFullPath)" />
-    <Exec Command="$(ClientAssetsBuildCommand) -- $(ClientAssetsBuildOutputParameter) $(_ClientAssetsOutputFullPath)" WorkingDirectory="$(ClientAssetsDirectory)" />
+    <Exec Command="$(ClientAssetsBuildCommand) -- $(ClientAssetsBuildOutputParameter) '$(_ClientAssetsOutputFullPath)'" WorkingDirectory="$(ClientAssetsDirectory)" />
 
     <ItemGroup>
       <_ClientAssetsBuildOutput Include="$(IntermediateOutputPath)clientassets\**"></_ClientAssetsBuildOutput>

--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <MakeDir Directories="$(_ClientAssetsOutputFullPath)" />
-    <Exec Command="$(ClientAssetsBuildCommand) -- $(ClientAssetsBuildOutputParameter) '$(_ClientAssetsOutputFullPath)'" WorkingDirectory="$(ClientAssetsDirectory)" />
+    <Exec Command="$(ClientAssetsBuildCommand) -- $(ClientAssetsBuildOutputParameter) &quot;$(_ClientAssetsOutputFullPath)&quot;" WorkingDirectory="$(ClientAssetsDirectory)" />
 
     <ItemGroup>
       <_ClientAssetsBuildOutput Include="$(IntermediateOutputPath)clientassets\**"></_ClientAssetsBuildOutput>


### PR DESCRIPTION
fixes: https://github.com/dotnet/aspnetcore/issues/38702

Assume the following:

when using the following scripts in ```package.json```
```
  "scripts": {
    "build": "npm run build:release",
    "build:Release": "webpack --mode production",
    "build:Debug": "webpack --mode development",
  }
```

When there are spaces in the output path, 

The build output shows:
`webpack --mode development "--output-path"
"D:\My" "Projects\Redacted\src\MyLibrary.Components\obj\Debug\net6.0\clientassets/"`

but should say:
`webpack --mode development --output-path
"D:\My Projects\Redacted\src\MyLibrary.Components\obj\Debug\net6.0\clientassets/"`

(for readability I put the path part on the next line)

This  PR fixes that.