### PR TITLE
Improve Swashbuckle gRPC XML docs

### DIFF
--- a/src/GrpcHttpApi/dependencies.props
+++ b/src/GrpcHttpApi/dependencies.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <GoogleApiCommonProtosPackageVersion>2.2.0</GoogleApiCommonProtosPackageVersion>
-    <GoogleProtobufPackageVersion>3.18.0</GoogleProtobufPackageVersion>
+    <GoogleProtobufPackageVersion>3.18.1</GoogleProtobufPackageVersion>
     <GrpcAspNetCoreServerPackageVersion>2.33.1</GrpcAspNetCoreServerPackageVersion>
     <GrpcCorePackageVersion>2.33.1</GrpcCorePackageVersion>
     <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.1</MicrosoftExtensionsLoggingTestingPackageVersion>

--- a/src/GrpcHttpApi/dependencies.props
+++ b/src/GrpcHttpApi/dependencies.props
@@ -8,6 +8,7 @@
     <GoogleProtobufPackageVersion>3.18.0</GoogleProtobufPackageVersion>
     <GrpcAspNetCoreServerPackageVersion>2.33.1</GrpcAspNetCoreServerPackageVersion>
     <GrpcCorePackageVersion>2.33.1</GrpcCorePackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.1</MicrosoftExtensionsLoggingTestingPackageVersion>
     <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.13.0</NUnit3TestAdapterPackageVersion>
     <SwashbuckleAspNetCorePackageVersion>6.1.4</SwashbuckleAspNetCorePackageVersion>

--- a/src/GrpcHttpApi/dependencies.props
+++ b/src/GrpcHttpApi/dependencies.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <GoogleApiCommonProtosPackageVersion>2.2.0</GoogleApiCommonProtosPackageVersion>
-    <GoogleProtobufPackageVersion>3.18.1</GoogleProtobufPackageVersion>
+    <GoogleProtobufPackageVersion>3.18.0</GoogleProtobufPackageVersion>
     <GrpcAspNetCoreServerPackageVersion>2.33.1</GrpcAspNetCoreServerPackageVersion>
     <GrpcCorePackageVersion>2.33.1</GrpcCorePackageVersion>
     <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.1</MicrosoftExtensionsLoggingTestingPackageVersion>

--- a/src/GrpcHttpApi/sample/Proto/greet.proto
+++ b/src/GrpcHttpApi/sample/Proto/greet.proto
@@ -7,12 +7,15 @@ import "google/api/annotations.proto";
 
 package greet;
 
+// Greeter service!
 service Greeter {
+  // SayHello method!
   rpc SayHello (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
       get: "/v1/greeter/{name}"
     };
   }
+  // SayHelloFrom method!
   rpc SayHelloFrom (HelloRequestFrom) returns (HelloReply) {
     option (google.api.http) = {
       post: "/v1/greeter"
@@ -21,15 +24,22 @@ service Greeter {
   }
 }
 
+// HelloRequest!
 message HelloRequest {
+  // Name!
   string name = 1;
 }
 
+// HelloRequestFrom!
 message HelloRequestFrom {
+  // Name!
   string name = 1;
+  // From!
   string from = 2;
 }
 
+// HelloReply!
 message HelloReply {
+  // Message!
   string message = 1;
 }

--- a/src/GrpcHttpApi/sample/Sample.sln
+++ b/src/GrpcHttpApi/sample/Sample.sln
@@ -5,10 +5,6 @@ VisualStudioVersion = 17.1.32104.313
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Grpc.HttpApi", "..\src\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj", "{6ED74B42-6C67-4783-92A1-8EA5998C36B4}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Grpc.Swagger", "..\src\Microsoft.AspNetCore.Grpc.Swagger\Microsoft.AspNetCore.Grpc.Swagger.csproj", "{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,14 +15,6 @@ Global
 		{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/GrpcHttpApi/sample/Sample.sln
+++ b/src/GrpcHttpApi/sample/Sample.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29521.150
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32104.313
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Grpc.HttpApi", "..\src\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj", "{6ED74B42-6C67-4783-92A1-8EA5998C36B4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Grpc.Swagger", "..\src\Microsoft.AspNetCore.Grpc.Swagger\Microsoft.AspNetCore.Grpc.Swagger.csproj", "{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +19,14 @@ Global
 		{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B12B366-4B8E-4B77-891C-7C3FE77D59D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ED74B42-6C67-4783-92A1-8EA5998C36B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFB8A9D1-12FF-4FBF-97C6-4DF498CA6A8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/GrpcHttpApi/sample/Server/Server.csproj
+++ b/src/GrpcHttpApi/sample/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,15 +11,8 @@
 
     <PackageReference Include="Grpc.Tools" Version="2.29.0" />
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.29.0" />
-    <!--<PackageReference Include="Microsoft.AspNetCore.Grpc.HttpApi" Version="0.1.0-alpha.20305.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Grpc.Swagger" Version="0.1.0-alpha.20305.2" />-->
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--<ProjectReference Include="..\..\..\..\..\Swashbuckle.AspNetCore\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />-->
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Grpc.Swagger\Microsoft.AspNetCore.Grpc.Swagger.csproj" />
-    <!--<ProjectReference Include="..\..\test\Microsoft.AspNetCore.Grpc.Swagger.Tests\Microsoft.AspNetCore.Grpc.Swagger.Tests.csproj" />-->
+    <PackageReference Include="Microsoft.AspNetCore.Grpc.HttpApi" Version="0.1.0-alpha.20305.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Grpc.Swagger" Version="0.1.0-alpha.20305.2" />
   </ItemGroup>
 
 </Project>

--- a/src/GrpcHttpApi/sample/Server/Server.csproj
+++ b/src/GrpcHttpApi/sample/Server/Server.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,8 +11,15 @@
 
     <PackageReference Include="Grpc.Tools" Version="2.29.0" />
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.29.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Grpc.HttpApi" Version="0.1.0-alpha.20305.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Grpc.Swagger" Version="0.1.0-alpha.20305.2" />
+    <!--<PackageReference Include="Microsoft.AspNetCore.Grpc.HttpApi" Version="0.1.0-alpha.20305.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Grpc.Swagger" Version="0.1.0-alpha.20305.2" />-->
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<ProjectReference Include="..\..\..\..\..\Swashbuckle.AspNetCore\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />-->
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Grpc.Swagger\Microsoft.AspNetCore.Grpc.Swagger.csproj" />
+    <!--<ProjectReference Include="..\..\test\Microsoft.AspNetCore.Grpc.Swagger.Tests\Microsoft.AspNetCore.Grpc.Swagger.Tests.csproj" />-->
   </ItemGroup>
 
 </Project>

--- a/src/GrpcHttpApi/sample/Server/Startup.cs
+++ b/src/GrpcHttpApi/sample/Server/Startup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,11 @@ namespace Server
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "gRPC HTTP API Example", Version = "v1" });
+
+                var filePath = Path.Combine(System.AppContext.BaseDirectory, "Microsoft.AspNetCore.Grpc.Swagger.Tests.xml");
+                c.IncludeXmlComments(filePath);
+
+                c.IncludeGrpcXmlComments(filePath, includeControllerXmlComments: true);
             });
             services.AddGrpcSwagger();
         }

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.HttpApi/HttpApiProviderSeviceBinder.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.HttpApi/HttpApiProviderSeviceBinder.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Grpc.HttpApi
                 var routePattern = RoutePatternFactory.Parse(pattern);
                 var routeParameterDescriptors = ServiceDescriptorHelpers.ResolveRouteParameterDescriptors(routePattern, methodDescriptor.InputType);
 
-                ServiceDescriptorHelpers.ResolveBodyDescriptor(body, methodDescriptor, out var bodyDescriptor, out var bodyFieldDescriptors, out var bodyDescriptorRepeated);
+                var bodyDescriptor = ServiceDescriptorHelpers.ResolveBodyDescriptor(body, typeof(TService), methodDescriptor);
 
                 FieldDescriptor? responseBodyDescriptor = null;
                 if (!string.IsNullOrEmpty(responseBody))
@@ -165,9 +165,9 @@ namespace Microsoft.AspNetCore.Grpc.HttpApi
                 var unaryServerCallHandler = new UnaryServerCallHandler<TService, TRequest, TResponse>(
                     unaryInvoker,
                     responseBodyDescriptor,
-                    bodyDescriptor,
-                    bodyDescriptorRepeated,
-                    bodyFieldDescriptors,
+                    bodyDescriptor?.Descriptor,
+                    bodyDescriptor?.IsDescriptorRepeated ?? false,
+                    bodyDescriptor?.FieldDescriptors,
                     routeParameterDescriptors,
                     _serializerOptions);
 

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.HttpApi/Microsoft.AspNetCore.Grpc.HttpApi.csproj
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.HttpApi/Microsoft.AspNetCore.Grpc.HttpApi.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
 
     <PackageReference Include="Google.Api.CommonProtos" Version="$(GoogleApiCommonProtosPackageVersion)" />
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/GrpcSwaggerGenOptionsExtensions.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/GrpcSwaggerGenOptionsExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Xml.XPath;
+using Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class GrpcSwaggerGenOptionsExtensions
+    {
+        /// <summary>
+        /// Inject human-friendly descriptions for Operations, Parameters and Schemas based on XML Comment files
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="xmlDocFactory">A factory method that returns XML Comments as an XPathDocument</param>
+        /// <param name="includeControllerXmlComments">
+        /// Flag to indicate if controller XML comments (i.e. summary) should be used to assign Tag descriptions.
+        /// Don't set this flag if you're customizing the default tag for operations via TagActionsBy.
+        /// </param>
+        public static void IncludeGrpcXmlComments(
+            this SwaggerGenOptions swaggerGenOptions,
+            Func<XPathDocument> xmlDocFactory,
+            bool includeControllerXmlComments = false)
+        {
+            var xmlDoc = xmlDocFactory();
+            swaggerGenOptions.OperationFilter<GrpcXmlCommentsOperationFilter>(xmlDoc);
+
+            if (includeControllerXmlComments)
+                swaggerGenOptions.DocumentFilter<GrpcXmlCommentsDocumentFilter>(xmlDoc);
+        }
+
+        /// <summary>
+        /// Inject human-friendly descriptions for Operations, Parameters and Schemas based on XML Comment files
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="filePath">An absolute path to the file that contains XML Comments</param>
+        /// <param name="includeControllerXmlComments">
+        /// Flag to indicate if controller XML comments (i.e. summary) should be used to assign Tag descriptions.
+        /// Don't set this flag if you're customizing the default tag for operations via TagActionsBy.
+        /// </param>
+        public static void IncludeGrpcXmlComments(
+            this SwaggerGenOptions swaggerGenOptions,
+            string filePath,
+            bool includeControllerXmlComments = false)
+        {
+            swaggerGenOptions.IncludeGrpcXmlComments(() => new XPathDocument(filePath), includeControllerXmlComments);
+        }
+    }
+}

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcDataContractResolver.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcDataContractResolver.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Shared.HttpApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Type = System.Type;
 
@@ -131,7 +132,10 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal
                     fieldType = MessageDescriptorHelpers.ResolveFieldType(field);
                 }
 
-                properties.Add(new DataProperty(field.JsonName, fieldType));
+                var propertyName = ServiceDescriptorHelpers.FormatUnderscoreName(field.Name, pascalCase: true, preservePeriod: false);
+                var propertyInfo = messageDescriptor.ClrType.GetProperty(propertyName);
+
+                properties.Add(new DataProperty(field.JsonName, fieldType, memberInfo: propertyInfo));
             }
 
             var schema = DataContract.ForObject(messageDescriptor.ClrType, properties: properties);

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcHttpApiDescriptionProvider.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcHttpApiDescriptionProvider.cs
@@ -8,6 +8,7 @@ using Google.Protobuf.Reflection;
 using Grpc.AspNetCore.Server;
 using Grpc.Shared.HttpApi;
 using Microsoft.AspNetCore.Grpc.HttpApi;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -77,6 +78,11 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal
                 ModelMetadata = new GrpcModelMetadata(ModelMetadataIdentity.ForType(methodDescriptor.OutputType.ClrType)),
                 StatusCode = 200
             });
+            var explorerSettings = routeEndpoint.Metadata.GetMetadata<ApiExplorerSettingsAttribute>();
+            if (explorerSettings != null)
+            {
+                apiDescription.GroupName = explorerSettings.GroupName;
+            }
 
             var methodMetadata = routeEndpoint.Metadata.GetMetadata<GrpcMethodMetadata>()!;
             var routeParameters = ServiceDescriptorHelpers.ResolveRouteParameterDescriptors(routeEndpoint.RoutePattern, methodDescriptor.InputType);

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcHttpApiDescriptionProvider.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcHttpApiDescriptionProvider.cs
@@ -5,10 +5,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Google.Api;
 using Google.Protobuf.Reflection;
+using Grpc.AspNetCore.Server;
 using Grpc.Shared.HttpApi;
 using Microsoft.AspNetCore.Grpc.HttpApi;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Routing;
@@ -64,7 +66,8 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal
                     // Swagger uses this to group endpoints together.
                     // Group methods together using the service name.
                     ["controller"] = methodDescriptor.Service.FullName
-                }
+                },
+                EndpointMetadata = routeEndpoint.Metadata.ToList()
             };
             apiDescription.RelativePath = pattern.TrimStart('/');
             apiDescription.SupportedRequestFormats.Add(new ApiRequestFormat { MediaType = "application/json" });
@@ -75,29 +78,48 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal
                 StatusCode = 200
             });
 
+            var methodMetadata = routeEndpoint.Metadata.GetMetadata<GrpcMethodMetadata>()!;
             var routeParameters = ServiceDescriptorHelpers.ResolveRouteParameterDescriptors(routeEndpoint.RoutePattern, methodDescriptor.InputType);
 
             foreach (var routeParameter in routeParameters)
             {
                 var field = routeParameter.Value.Last();
+                var parameterName = ServiceDescriptorHelpers.FormatUnderscoreName(field.Name, pascalCase: true, preservePeriod: false);
+                var propertyInfo = field.ContainingType.ClrType.GetProperty(parameterName);
+
+                // If from a property, create model as property to get its XML comments.
+                var identity = propertyInfo != null
+                    ? ModelMetadataIdentity.ForProperty(propertyInfo, MessageDescriptorHelpers.ResolveFieldType(field), field.ContainingType.ClrType)
+                    : ModelMetadataIdentity.ForType(MessageDescriptorHelpers.ResolveFieldType(field));
 
                 apiDescription.ParameterDescriptions.Add(new ApiParameterDescription
                 {
                     Name = routeParameter.Key,
-                    ModelMetadata = new GrpcModelMetadata(ModelMetadataIdentity.ForType(MessageDescriptorHelpers.ResolveFieldType(field))),
+                    ModelMetadata = new GrpcModelMetadata(identity),
                     Source = BindingSource.Path,
                     DefaultValue = string.Empty
                 });
             }
 
-            ServiceDescriptorHelpers.ResolveBodyDescriptor(httpRule.Body, methodDescriptor, out var bodyDescriptor, out _, out _);
+            var bodyDescriptor = ServiceDescriptorHelpers.ResolveBodyDescriptor(httpRule.Body, methodMetadata.ServiceType, methodDescriptor);
             if (bodyDescriptor != null)
             {
+                // If from a property, create model as property to get its XML comments.
+                var identity = bodyDescriptor.PropertyInfo != null
+                    ? ModelMetadataIdentity.ForProperty(bodyDescriptor.PropertyInfo, bodyDescriptor.Descriptor.ClrType, bodyDescriptor.PropertyInfo.DeclaringType!)
+                    : ModelMetadataIdentity.ForType(bodyDescriptor.Descriptor.ClrType);
+
+                // Or if from a parameter, create model as parameter to get its XML comments.
+                var parameterDescriptor = bodyDescriptor.ParameterInfo != null
+                    ? new ControllerParameterDescriptor { ParameterInfo = bodyDescriptor.ParameterInfo }
+                    : null;
+
                 apiDescription.ParameterDescriptions.Add(new ApiParameterDescription
                 {
                     Name = "Input",
-                    ModelMetadata = new GrpcModelMetadata(ModelMetadataIdentity.ForType(bodyDescriptor.ClrType)),
-                    Source = BindingSource.Body
+                    ModelMetadata = new GrpcModelMetadata(identity),
+                    Source = BindingSource.Body,
+                    ParameterDescriptor = parameterDescriptor!
                 });
             }
 

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsDocumentFilter.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsDocumentFilter.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.XPath;
+using Grpc.AspNetCore.Server;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments
+{
+    internal class GrpcXmlCommentsDocumentFilter : IDocumentFilter
+    {
+        private const string MemberXPath = "/doc/members/member[@name='{0}']";
+        private const string SummaryTag = "summary";
+
+        private readonly XPathNavigator _xmlNavigator;
+
+        public GrpcXmlCommentsDocumentFilter(XPathDocument xmlDoc)
+        {
+            _xmlNavigator = xmlDoc.CreateNavigator();
+        }
+
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            // Get unique services
+            var nameAndServiceDescriptor = context.ApiDescriptions
+                .Select(apiDesc => apiDesc.ActionDescriptor)
+                .Where(actionDesc => actionDesc != null && (actionDesc.EndpointMetadata?.Any(m => m is GrpcMethodMetadata) ?? false))
+                .GroupBy(actionDesc => actionDesc.RouteValues["controller"]!)
+                .Select(group => new KeyValuePair<string, ActionDescriptor>(group.Key, group.First()));
+
+            foreach (var nameAndType in nameAndServiceDescriptor)
+            {
+                var grpcMethodMetadata = nameAndType.Value.EndpointMetadata.OfType<GrpcMethodMetadata>().First();
+                if (TryAdd(swaggerDoc, nameAndType, grpcMethodMetadata.ServiceType))
+                {
+                    continue;
+                }
+
+                if (grpcMethodMetadata.ServiceType.BaseType?.DeclaringType is { } staticService)
+                {
+                    if (TryAdd(swaggerDoc, nameAndType, staticService))
+                    {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        private bool TryAdd(OpenApiDocument swaggerDoc, KeyValuePair<string, ActionDescriptor> nameAndType, Type type)
+        {
+            var memberName = XmlCommentsNodeNameHelper.GetMemberNameForType(type);
+            var typeNode = _xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
+
+            if (typeNode != null)
+            {
+                var summaryNode = typeNode.SelectSingleNode(SummaryTag);
+                if (summaryNode != null)
+                {
+                    if (swaggerDoc.Tags == null)
+                        swaggerDoc.Tags = new List<OpenApiTag>();
+
+                    swaggerDoc.Tags.Add(new OpenApiTag
+                    {
+                        Name = nameAndType.Key,
+                        Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml)
+                    });
+                }
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsOperationFilter.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsOperationFilter.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Xml.XPath;
+using Grpc.AspNetCore.Server;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments
+{
+    internal class GrpcXmlCommentsOperationFilter : IOperationFilter
+    {
+        private readonly XPathNavigator _xmlNavigator;
+
+        public GrpcXmlCommentsOperationFilter(XPathDocument xmlDoc)
+        {
+            _xmlNavigator = xmlDoc.CreateNavigator();
+        }
+
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var grpcMetadata = context.ApiDescription.ActionDescriptor.EndpointMetadata.OfType<GrpcMethodMetadata>().FirstOrDefault();
+            if (grpcMetadata == null) return;
+
+            var methodInfo = grpcMetadata.ServiceType.GetMethod(grpcMetadata.Method.Name);
+            if (methodInfo == null) return;
+
+            // If method is from a constructed generic type, look for comments from the generic type method
+            var targetMethod = methodInfo.DeclaringType!.IsConstructedGenericType
+                ? methodInfo.GetUnderlyingGenericTypeMethod()
+                : methodInfo;
+
+            if (targetMethod == null)
+            {
+                return;
+            }
+
+            // Base service never has response tags.
+            ApplyServiceTags(operation, targetMethod.DeclaringType!);
+
+            if (TryApplyMethodTags(operation, targetMethod))
+            {
+                return;
+            }
+
+            if (targetMethod.IsVirtual && targetMethod.GetBaseDefinition() is { } baseMethod)
+            {
+                if (TryApplyMethodTags(operation, baseMethod))
+                {
+                    return;
+                }
+            }
+        }
+
+        private void ApplyServiceTags(OpenApiOperation operation, Type controllerType)
+        {
+            var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(controllerType);
+            var responseNodes = _xmlNavigator.Select($"/doc/members/member[@name='{typeMemberName}']/response");
+            ApplyResponseTags(operation, responseNodes);
+        }
+
+        private bool TryApplyMethodTags(OpenApiOperation operation, MethodInfo methodInfo)
+        {
+            var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(methodInfo);
+            var methodNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{methodMemberName}']");
+
+            if (methodNode == null)
+            {
+                return false;
+            }
+
+            var summaryNode = methodNode.SelectSingleNode("summary");
+            if (summaryNode != null)
+                operation.Summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
+
+            var remarksNode = methodNode.SelectSingleNode("remarks");
+            if (remarksNode != null)
+                operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml);
+
+            var responseNodes = methodNode.Select("response");
+            ApplyResponseTags(operation, responseNodes);
+
+            return true;
+        }
+
+        private void ApplyResponseTags(OpenApiOperation operation, XPathNodeIterator responseNodes)
+        {
+            while (responseNodes.MoveNext())
+            {
+                var code = responseNodes.Current!.GetAttribute("code", "");
+                var response = operation.Responses.ContainsKey(code)
+                    ? operation.Responses[code]
+                    : operation.Responses[code] = new OpenApiResponse();
+
+                response.Description = XmlCommentsTextHelper.Humanize(responseNodes.Current.InnerXml);
+            }
+        }
+    }
+}

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
@@ -18,8 +18,6 @@
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <!--<ProjectReference Include="..\..\..\..\..\Swashbuckle.AspNetCore\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />-->
-
     <ProjectReference Include="..\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj" />
 
     <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCorePackageVersion)" />

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
@@ -18,6 +18,8 @@
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
+    <!--<ProjectReference Include="..\..\..\..\..\Swashbuckle.AspNetCore\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />-->
+
     <ProjectReference Include="..\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj" />
 
     <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCorePackageVersion)" />

--- a/src/GrpcHttpApi/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/GrpcHttpApi/src/Shared/ServiceDescriptorHelpers.cs
@@ -274,38 +274,108 @@ namespace Grpc.Shared.HttpApi
             return routeParameterDescriptors;
         }
 
-        public static void ResolveBodyDescriptor(string body, MethodDescriptor methodDescriptor, out MessageDescriptor? bodyDescriptor, out List<FieldDescriptor>? bodyFieldDescriptors, out bool bodyDescriptorRepeated)
+        public static BodyDescriptorInfo? ResolveBodyDescriptor(string body, Type serviceType, MethodDescriptor methodDescriptor)
         {
-            bodyDescriptor = null;
-            bodyFieldDescriptors = null;
-            bodyDescriptorRepeated = false;
-
             if (!string.IsNullOrEmpty(body))
             {
                 if (!string.Equals(body, "*", StringComparison.Ordinal))
                 {
-                    if (!TryResolveDescriptors(methodDescriptor.InputType, body, out bodyFieldDescriptors))
+                    if (!TryResolveDescriptors(methodDescriptor.InputType, body, out var bodyFieldDescriptors))
                     {
                         throw new InvalidOperationException($"Couldn't find matching field for body '{body}' on {methodDescriptor.InputType.Name}.");
                     }
                     var leafDescriptor = bodyFieldDescriptors.Last();
+                    var propertyName = FormatUnderscoreName(leafDescriptor.Name, pascalCase: true, preservePeriod: false);
+                    var propertyInfo = leafDescriptor.ContainingType.ClrType.GetProperty(propertyName);
+
                     if (leafDescriptor.IsRepeated)
                     {
                         // A repeating field isn't a message type. The JSON parser will parse using the containing
                         // type to get the repeating collection.
-                        bodyDescriptor = leafDescriptor.ContainingType;
-                        bodyDescriptorRepeated = true;
+                        return new BodyDescriptorInfo(leafDescriptor.ContainingType, bodyFieldDescriptors, IsDescriptorRepeated: true, propertyInfo);
                     }
                     else
                     {
-                        bodyDescriptor = leafDescriptor.MessageType;
+                        return new BodyDescriptorInfo(leafDescriptor.MessageType, bodyFieldDescriptors, IsDescriptorRepeated: false, propertyInfo);
                     }
                 }
                 else
                 {
-                    bodyDescriptor = methodDescriptor.InputType;
+                    ParameterInfo? requestParameter = null;
+                    var methodInfo = serviceType.GetMethod(methodDescriptor.Name);
+                    if (methodInfo != null)
+                    {
+                        requestParameter = methodInfo.GetParameters().SingleOrDefault(p => p.Name == "request");
+                    }
+
+                    return new BodyDescriptorInfo(methodDescriptor.InputType, FieldDescriptors: null, IsDescriptorRepeated: false, ParameterInfo: requestParameter);
                 }
             }
+
+            return null;
+        }
+
+        public record BodyDescriptorInfo(
+            MessageDescriptor Descriptor,
+            List<FieldDescriptor>? FieldDescriptors,
+            bool IsDescriptorRepeated,
+            PropertyInfo? PropertyInfo = null,
+            ParameterInfo? ParameterInfo = null);
+
+        public static string FormatUnderscoreName(string input, bool pascalCase, bool preservePeriod)
+        {
+            var capitalizeNext = pascalCase;
+            var result = string.Empty;
+
+            for (var i = 0; i < input.Length; i++)
+            {
+                if (char.IsLower(input[i]))
+                {
+                    if (capitalizeNext)
+                    {
+                        result += char.ToUpper(input[i]);
+                    }
+                    else
+                    {
+                        result += input[i];
+                    }
+                    capitalizeNext = false;
+                }
+                else if (char.IsUpper(input[i]))
+                {
+                    if (i == 0 && !capitalizeNext)
+                    {
+                        // Force first letter to lower-case unless explicitly told to
+                        // capitalize it.
+                        result += char.ToLower(input[i]);
+                    }
+                    else
+                    {
+                        // Capital letters after the first are left as-is.
+                        result += input[i];
+                    }
+                    capitalizeNext = false;
+                }
+                else if (char.IsDigit(input[i]))
+                {
+                    result += input[i];
+                    capitalizeNext = true;
+                }
+                else
+                {
+                    capitalizeNext = true;
+                    if (input[i] == '.' && preservePeriod)
+                    {
+                        result += '.';
+                    }
+                }
+            }
+            // Add a trailing "_" if the name should be altered.
+            if (input.Length > 0 && input[input.Length - 1] == '#')
+            {
+                result += '_';
+            }
+            return result;
         }
     }
 }

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/HttpApiServerCallContextTests.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/HttpApiServerCallContextTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Threading;
-using Microsoft.AspNetCore.Grpc.HttpApi;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/Microsoft.AspNetCore.Grpc.HttpApi.Tests.csproj
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/Microsoft.AspNetCore.Grpc.HttpApi.Tests.csproj
@@ -15,6 +15,8 @@
 
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Grpc.HttpApi\Microsoft.AspNetCore.Grpc.HttpApi.csproj" />
 
+    <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
+
     <PackageReference Include="Grpc.Tools" Version="$(GrpcCorePackageVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/Proto/httpapi.proto
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/Proto/httpapi.proto
@@ -94,6 +94,24 @@ service HttpApiInvalidPatternGreeter {
   }
 }
 
+service HttpApiStreaming {
+  rpc GetServerStreaming (HelloRequest) returns (stream HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/server_greeter/{name}"
+    };
+  }
+  rpc GetClientStreaming (stream HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/client_greeter/{name}"
+    };
+  }
+  rpc GetBidiStreaming (stream HelloRequest) returns (stream HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/bidi_greeter/{name}"
+    };
+  }
+}
+
 message HelloRequest {
   message SubMessage {
     string subfield = 1;

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/TestObjects/Services/HttpApiStreamingService.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.Tests/TestObjects/Services/HttpApiStreamingService.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using HttpApi;
+
+namespace Microsoft.AspNetCore.Grpc.HttpApi.Tests.TestObjects
+{
+    public class HttpApiStreamingService : HttpApiStreaming.HttpApiStreamingBase
+    {
+    }
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/GrpcSwaggerServiceExtensionsTests.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/GrpcSwaggerServiceExtensionsTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Count;
 using Greet;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.OpenApi.Models;
@@ -47,6 +49,44 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Tests
             Assert.True(path.Operations.ContainsKey(OperationType.Get));
         }
 
+        [Fact]
+        public void AddGrpcSwagger_GrpcServiceWithGroupName_FilteredByGroup()
+        {
+            // Arrange & Act
+            var services = new ServiceCollection();
+            services.AddGrpcSwagger();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+                c.SwaggerDoc("v2", new OpenApiInfo { Title = "My API", Version = "v2" });
+            });
+            services.AddRouting();
+            services.AddLogging();
+            services.AddSingleton<IWebHostEnvironment, TestWebHostEnvironment>();
+            var serviceProvider = services.BuildServiceProvider();
+            var app = new ApplicationBuilder(serviceProvider);
+
+            app.UseRouting();
+            app.UseEndpoints(c =>
+            {
+                c.MapGrpcService<GreeterService>();
+                c.MapGrpcService<CounterService>();
+            });
+
+            var swaggerGenerator = serviceProvider.GetRequiredService<ISwaggerProvider>();
+
+            // Assert 1
+            var swagger = swaggerGenerator.GetSwagger("v1");
+            Assert.Single(swagger.Paths);
+            Assert.True(swagger.Paths["/v1/greeter/{name}"].Operations.ContainsKey(OperationType.Get));
+
+            // Assert 2
+            swagger = swaggerGenerator.GetSwagger("v2");
+            Assert.Equal(2, swagger.Paths.Count);
+            Assert.True(swagger.Paths["/v1/greeter/{name}"].Operations.ContainsKey(OperationType.Get));
+            Assert.True(swagger.Paths["/v1/add/{value1}/{value2}"].Operations.ContainsKey(OperationType.Get));
+        }
+
         private class TestWebHostEnvironment : IWebHostEnvironment
         {
             public IFileProvider WebRootFileProvider { get; set; } = default!;
@@ -58,6 +98,11 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Tests
         }
 
         private class GreeterService : Greeter.GreeterBase
+        {
+        }
+
+        [ApiExplorerSettings(GroupName = "v2")]
+        private class CounterService : Counter.CounterBase
         {
         }
     }

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Microsoft.AspNetCore.Grpc.Swagger.Tests.csproj
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Microsoft.AspNetCore.Grpc.Swagger.Tests.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Proto\counter.proto" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Proto\counter.proto" GrpcServices="Both" />
     <Protobuf Include="Proto\xmldoc.proto" GrpcServices="Both" />
     <Protobuf Include="Proto\greeter.proto" GrpcServices="Both" />
     <Protobuf Include="Proto\messages.proto" GrpcServices="Both" />

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Microsoft.AspNetCore.Grpc.Swagger.Tests.csproj
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Microsoft.AspNetCore.Grpc.Swagger.Tests.csproj
@@ -3,15 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Proto\greeter.proto" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <Protobuf Include="Proto\xmldoc.proto" GrpcServices="Both" />
     <Protobuf Include="Proto\greeter.proto" GrpcServices="Both" />
-    <Protobuf Include="Proto\httpapi.proto" GrpcServices="Both" />
+    <Protobuf Include="Proto\messages.proto" GrpcServices="Both" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/counter.proto
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/counter.proto
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+
+package count;
+
+service Counter {
+  rpc Add (CountRequest) returns (CountReply) {
+    option (google.api.http) = {
+      get: "/v1/add/{value1}/{value2}"
+    };
+  }
+}
+
+message CountRequest {
+  int32 value1 = 1;
+  int32 value2 = 2;
+}
+
+message CountReply {
+  int32 result = 1;
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/greeter.proto
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/greeter.proto
@@ -7,7 +7,9 @@ import "google/api/annotations.proto";
 
 package greet;
 
+// Greeter!
 service Greeter {
+  // SayHello!
   rpc SayHello (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
       get: "/v1/greeter/{name}"
@@ -15,10 +17,14 @@ service Greeter {
   }
 }
 
+// HelloRequest!
 message HelloRequest {
+  // Name!
   string name = 1;
 }
 
+// HelloReply!
 message HelloReply {
+  // Message!
   string message = 1;
 }

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/messages.proto
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/messages.proto
@@ -3,91 +3,9 @@
 
 syntax = "proto3";
 
-import "google/api/annotations.proto";
 import "google/protobuf/wrappers.proto";
 
-package http_api;
-
-service HttpApiGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      get: "/v1/greeter/SayHello/{name}"
-    };
-  }
-  rpc ResponseBody (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      get: "/v1/greeter/ResponseBody/{name}"
-      response_body: "message"
-    };
-  }
-  rpc Custom (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      custom: {
-        kind: "HEAD",
-        path: "/v1/greeter/Custom/{name}"
-      }
-    };
-  }
-  rpc AdditionalBindings (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      get: "/v1/additional_bindings/{name}"
-      additional_bindings {
-        delete: "/v1/additional_bindings/{name}"
-      }
-    };
-  }
-  rpc NoOption (HelloRequest) returns (HelloReply);
-  rpc ServerStreamingGetOption (HelloRequest) returns (stream HelloReply) {
-    option (google.api.http) = {
-      get: "/v1/greeter/ServerStreamingGetOption/{name}"
-    };
-  }
-  rpc Body (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      post: "/v1/greeter/Body"
-      body: "*"
-    };
-  }
-  rpc SubBody (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      post: "/v1/greeter/SubBody"
-      body: "sub"
-    };
-  }
-  rpc SubRepeatedBody (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      post: "/v1/greeter/SubRepeatedBody"
-      body: "repeated_strings"
-    };
-  }
-}
-
-service HttpApiInvalidResponseBodyGreeter {
-  rpc BadResponseBody (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      get: "/v1/greeter/BadResponseBody/{name}"
-      response_body: "NoMatch"
-    };
-  }
-}
-
-service HttpApiInvalidBodyGreeter {
-  rpc BadBody (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      get: "/v1/greeter/BadBody/{name}"
-      body: "NoMatch"
-    };
-  }
-}
-
-service HttpApiInvalidPatternGreeter {
-  rpc BadPattern (HelloRequest) returns (HelloReply) {
-    option (google.api.http) = {
-      get: "v1/greeter/BadPattern/{name}"
-      body: "NoMatch"
-    };
-  }
-}
+package messages;
 
 message HelloRequest {
   message SubMessage {

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/xmldoc.proto
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/xmldoc.proto
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+
+package xmldoc;
+
+// XmlDoc!
+service XmlDoc {
+  // BasicGet!
+  rpc BasicGet (StringRequest) returns (StringReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name}"
+    };
+  }
+  // BodyRootPost!
+  rpc BodyRootPost (StringRequestWithDetail) returns (StringReply) {
+    option (google.api.http) = {
+      post: "/v1/greeter",
+      body: "*"
+    };
+  }
+  // BodyPathPost!
+  rpc BodyPathPost (StringRequestWithDetail) returns (StringReply) {
+    option (google.api.http) = {
+      post: "/v1/greeter/{name}",
+      body: "detail"
+    };
+  }
+  // BasicDelete!
+  rpc BasicDelete (StringRequest) returns (StringReply) {
+    option (google.api.http) = {
+      delete: "/v1/greeter/{name}"
+    };
+  }
+}
+
+// StringRequest!
+message StringRequest {
+  // Name field!
+  string name = 1;
+}
+
+// StringRequestWithDetail!
+message StringRequestWithDetail {
+  // Name field!
+  string name = 1;
+  // Detail field!
+  StringRequestWithDetail.Detail detail = 2;
+
+  // Detail!
+  message Detail {
+    // Age field!
+    int32 age = 1;
+  }
+}
+
+// StringReply!
+message StringReply {
+  // Message field!
+  string message = 1;
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/SchemaGeneratorIntegrationTests.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/SchemaGeneratorIntegrationTests.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json;
 using Google.Protobuf.WellKnownTypes;
-using HttpApi;
+using Messages;
 using Microsoft.AspNetCore.Grpc.Swagger.Internal;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Services/GreeterService.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Services/GreeterService.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Greet;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Tests.Services
+{
+    public class GreeterService : Greeter.GreeterBase
+    {
+        private readonly ILogger _logger;
+
+        public GreeterService(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<GreeterService>();
+        }
+
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            _logger.LogInformation($"Sending hello to {request.Name}");
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name}" });
+        }
+    }
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Services/XmlDocService.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Services/XmlDocService.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Greet;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Xmldoc;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Tests.Services
+{
+    public class XmlDocService : XmlDoc.XmlDocBase
+    {
+        private readonly ILogger _logger;
+
+        public XmlDocService(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<XmlDocServiceWithComments>();
+        }
+
+        public override Task<StringReply> BasicGet(StringRequest request, ServerCallContext context)
+        {
+            return base.BasicGet(request, context);
+        }
+
+        public override Task<StringReply> BodyRootPost(StringRequestWithDetail request, ServerCallContext context)
+        {
+            return base.BodyRootPost(request, context);
+        }
+
+        public override Task<StringReply> BodyPathPost(StringRequestWithDetail request, ServerCallContext context)
+        {
+            return base.BodyPathPost(request, context);
+        }
+    }
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Services/XmlDocServiceWithComments.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Services/XmlDocServiceWithComments.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Greet;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Xmldoc;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Tests.Services
+{
+    /// <summary>
+    /// XmlDocServiceWithComments XML comment!
+    /// </summary>
+    public class XmlDocServiceWithComments : XmlDoc.XmlDocBase
+    {
+        private readonly ILogger _logger;
+
+        public XmlDocServiceWithComments(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<XmlDocServiceWithComments>();
+        }
+
+        /// <summary>
+        /// BasicGet XML summary!
+        /// </summary>
+        /// <remarks>
+        /// BasicGet XML remarks!
+        /// </remarks>
+        /// <param name="request">Request XML comment!</param>
+        /// <param name="context"></param>
+        /// <response code="200">Returns the newly created item!</response>
+        /// <response code="404">Not found!</response>
+        /// <returns>Returns comment!</returns>
+        public override Task<StringReply> BasicGet(StringRequest request, ServerCallContext context)
+        {
+            return base.BasicGet(request, context);
+        }
+
+        /// <summary>
+        /// BodyRootPost XML summary!
+        /// </summary>
+        /// <param name="request">Request XML param!</param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public override Task<StringReply> BodyRootPost(StringRequestWithDetail request, ServerCallContext context)
+        {
+            return base.BodyRootPost(request, context);
+        }
+    }
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/XmlComments/XmlCommentsDocumentFilterTests.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/XmlComments/XmlCommentsDocumentFilterTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.XPath;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments;
+using Microsoft.AspNetCore.Grpc.Swagger.Tests.Services;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Tests.XmlComments
+{
+    public class XmlCommentsDocumentFilterTests
+    {
+        private class TestMethod : IMethod
+        {
+            public MethodType Type { get; }
+            public string ServiceName { get; } = "TestServiceName";
+            public string Name { get; } = "TestName";
+            public string FullName => ServiceName + "." + Name;
+        }
+
+        [Theory]
+        [InlineData(typeof(XmlDocService), "XmlDoc!")]
+        [InlineData(typeof(XmlDocServiceWithComments), "XmlDocServiceWithComments XML comment!")]
+        public void Apply_SetsTagDescription_FromControllerSummaryTags(Type serviceType, string expectedDescription)
+        {
+            var document = new OpenApiDocument();
+            var filterContext = new DocumentFilterContext(
+                new[]
+                {
+                    CreateApiDescription(serviceType),
+                    CreateApiDescription(serviceType)
+                },
+                null,
+                null);
+
+            Subject().Apply(document, filterContext);
+
+            Assert.Equal(1, document.Tags.Count);
+            Assert.Equal(expectedDescription, document.Tags[0].Description);
+
+            static ApiDescription CreateApiDescription(Type serviceType)
+            {
+                return new ApiDescription
+                {
+                    ActionDescriptor = new ActionDescriptor
+                    {
+                        RouteValues =
+                        {
+                            ["controller"] = "greet.Greeter"
+                        },
+                        EndpointMetadata = new List<object>
+                        {
+                            new GrpcMethodMetadata(serviceType, new TestMethod())
+                        }
+                    }
+                };
+            }
+        }
+
+        private GrpcXmlCommentsDocumentFilter Subject()
+        {
+            using (var xmlComments = File.OpenText($"{typeof(GreeterService).Assembly.GetName().Name}.xml"))
+            {
+                return new GrpcXmlCommentsDocumentFilter(new XPathDocument(xmlComments));
+            }
+        }
+    }
+}

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/XmlComments/XmlDocumentationIntegrationTests.cs
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/XmlComments/XmlDocumentationIntegrationTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Xml.XPath;
+using Greet;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments;
+using Microsoft.AspNetCore.Grpc.Swagger.Tests.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Swashbuckle.AspNetCore.Swagger;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Grpc.Swagger.Tests.XmlComments
+{
+    public class XmlDocumentationIntegrationTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XmlDocumentationIntegrationTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void ServiceDescription_ModelHasXmlDocs_UseXmlDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocServiceWithComments>();
+
+            // Assert
+            Assert.Equal("xmldoc.XmlDoc", swagger.Tags[0].Name);
+            Assert.Equal("XmlDocServiceWithComments XML comment!", swagger.Tags[0].Description);
+        }
+
+        [Fact]
+        public void ServiceDescription_ModelDoesntHaveXmlDocs_UseProtoDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocService>();
+
+            // Assert
+            Assert.Equal("xmldoc.XmlDoc", swagger.Tags[0].Name);
+            Assert.Equal("XmlDoc!", swagger.Tags[0].Description);
+        }
+
+        [Fact]
+        public void RouteParameter_UseProtoDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocServiceWithComments>();
+
+            // Assert
+            var path = swagger.Paths["/v1/greeter/{name}"];
+            Assert.Equal("Name field!", path.Operations[OperationType.Get].Parameters[0].Description);
+        }
+
+        [Fact]
+        public void MethodDescription_ModelHasXmlDocs_UseXmlDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocServiceWithComments>();
+
+            // Assert
+            var path = swagger.Paths["/v1/greeter/{name}"];
+            Assert.Equal("BasicGet XML summary!", path.Operations[OperationType.Get].Summary);
+            Assert.Equal("BasicGet XML remarks!", path.Operations[OperationType.Get].Description);
+        }
+
+        [Fact]
+        public void MethodDescription_ModelDoesntHaveXmlDocs_UseProtoDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocService>();
+
+            // Assert
+            var path = swagger.Paths["/v1/greeter/{name}"];
+            Assert.Equal("BasicGet!", path.Operations[OperationType.Get].Summary);
+            Assert.Null(path.Operations[OperationType.Get].Description);
+        }
+
+        [Fact]
+        public void RequestDescription_Root_ModelHasXmlDocs_UseXmlDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocServiceWithComments>();
+
+            // Assert
+            var path = swagger.Paths["/v1/greeter"];
+            Assert.Equal("Request XML param!", path.Operations[OperationType.Post].RequestBody.Description);
+        }
+
+        [Fact]
+        public void RequestDescription_Root_ModelDoesntHaveXmlDocs_Empty()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocService>();
+
+            // Assert
+            var path = swagger.Paths["/v1/greeter"];
+            Assert.Null(path.Operations[OperationType.Post].RequestBody.Description);
+        }
+
+        [Fact]
+        public void RequestDescription_Nested_ProtoFieldDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocService>();
+
+            // Assert
+            var path = swagger.Paths["/v1/greeter/{name}"];
+            Assert.Equal("Detail field!", path.Operations[OperationType.Post].RequestBody.Description);
+        }
+
+        [Fact]
+        public void Message_UseProtoDocs()
+        {
+            // Arrange & Act
+            var swagger = GetOpenApiDocument<XmlDocServiceWithComments>();
+
+            // Assert
+            var helloReplyMessage = swagger.Components.Schemas["StringReply"];
+            Assert.Equal("StringReply!", helloReplyMessage.Description);
+            Assert.Equal("Message field!", helloReplyMessage.Properties["message"].Description);
+        }
+
+        private OpenApiDocument GetOpenApiDocument<TService>() where TService : class
+        {
+            var services = new ServiceCollection();
+            services.AddGrpcSwagger();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+
+                var filePath = Path.Combine(System.AppContext.BaseDirectory, "Microsoft.AspNetCore.Grpc.Swagger.Tests.xml");
+                c.IncludeXmlComments(filePath);
+                c.IncludeGrpcXmlComments(filePath, includeControllerXmlComments: true);
+            });
+            services.AddRouting();
+            services.AddLogging();
+            services.AddSingleton<IWebHostEnvironment, TestWebHostEnvironment>();
+            var serviceProvider = services.BuildServiceProvider();
+            var app = new ApplicationBuilder(serviceProvider);
+
+            app.UseRouting();
+            app.UseEndpoints(c =>
+            {
+                c.MapGrpcService<TService>();
+            });
+
+            var swaggerGenerator = serviceProvider.GetRequiredService<ISwaggerProvider>();
+            var swagger = swaggerGenerator.GetSwagger("v1");
+
+            using var outputString = new StringWriter();
+            swagger.SerializeAsV3(new OpenApiJsonWriter(outputString));
+            _testOutputHelper.WriteLine(outputString.ToString());
+
+            return swagger;
+        }
+
+        private class TestWebHostEnvironment : IWebHostEnvironment
+        {
+            public IFileProvider WebRootFileProvider { get; set; } = default!;
+            public string WebRootPath { get; set; } = default!;
+            public string? ApplicationName { get; set; }
+            public IFileProvider? ContentRootFileProvider { get; set; }
+            public string? ContentRootPath { get; set; }
+            public string? EnvironmentName { get; set; }
+        }
+
+        private class GreeterService : Greeter.GreeterBase
+        {
+        }
+    }
+}


### PR DESCRIPTION
Two general improvements:
1. Specify property, parameter, and method types in API descriptions. Swashbuckle uses these to pull data from XML docs.
2. Create a couple of custom XML doc filters that are specific to gRPC types.