### PR TITLE
Set FormatEnumsAsIntegers to true by default

### DIFF
--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.HttpApi/JsonSettings.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.HttpApi/JsonSettings.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Grpc.HttpApi
         /// </summary>
         public bool FormatDefaultValues { get; set; } = true;
 
-        public bool FormatEnumsAsIntegers { get; set; }
+        public bool FormatEnumsAsIntegers { get; set; } = true;
 
         public TypeRegistry TypeRegistry { get; set; } = TypeRegistry.Empty;
 


### PR DESCRIPTION
Enums should be formatted as integers by default, as deserializing string-based enums can cause exceptions when the value names (not the values themselves) are changed, or when new values are added (unlike integers, which are handled gracefully on deserialization generally).