### PR TITLE
Fix wrong swagger schema generation when `response_body` is set.

### DIFF
--- a/src/GrpcHttpApi/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/GrpcHttpApi/src/Shared/ServiceDescriptorHelpers.cs
@@ -318,6 +318,18 @@ namespace Grpc.Shared.HttpApi
             return null;
         }
 
+        public static FieldDescriptor ResolveResponseBodyDescriptor(string responseBody, MethodDescriptor methodDescriptor)
+        {
+            if (!TryResolveDescriptors(methodDescriptor.OutputType, responseBody, out var responseBodyFieldDescriptors))
+            {
+                throw new InvalidOperationException($"Couldn't find matching field for response-body '{responseBody}' on {methodDescriptor.OutputType.Name}.");
+            }
+
+            var fieldDescriptor = responseBodyFieldDescriptors.Last();
+            return fieldDescriptor;
+
+        }
+
         public record BodyDescriptorInfo(
             MessageDescriptor Descriptor,
             List<FieldDescriptor>? FieldDescriptors,


### PR DESCRIPTION
When `response_body` is set in the proto file, the swagger still displays the schema from the `response` (actually MethodDescriptor.OutputType.ClrType) instead of `response[response_body]` while the data returned from the service is correct as expected.

This PR fixes the wrong swagger schema generation.