### PR TITLE
Add runtime helper for migration content root

### DIFF
--- a/src/SystemWebAdapters/samples/MvcApp/MvcApp.csproj
+++ b/src/SystemWebAdapters/samples/MvcApp/MvcApp.csproj
@@ -25,6 +25,9 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <MigrationKind>yarp</MigrationKind>
+    <MigrateToProjectPath>..\MvcCoreApp\MvcCoreApp.csproj</MigrateToProjectPath>
+    <MigrateToProjectGuid>b1d06f62-b315-4ed8-8109-168b4d4e4b86</MigrateToProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/SystemWebAdapters/samples/MvcCoreApp/MvcCoreApp.csproj
+++ b/src/SystemWebAdapters/samples/MvcCoreApp/MvcCoreApp.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
   </ItemGroup>
 

--- a/src/SystemWebAdapters/samples/MvcCoreApp/Program.cs
+++ b/src/SystemWebAdapters/samples/MvcCoreApp/Program.cs
@@ -1,6 +1,7 @@
 using System.Web.Adapters;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(MigrationWebApplicationOptions.CreateWithRelativeContentRoute(args));
+builder.Services.AddReverseProxy().LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
@@ -25,8 +26,10 @@ app.UseAuthorization();
 
 app.UseSystemWebAdapters();
 
-app.MapControllerRoute(
-    name: "default",
-    pattern: "{controller=Home}/{action=Index}/{id?}");
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapDefaultControllerRoute();
+    endpoints.MapReverseProxy();
+});
 
 app.Run();

--- a/src/SystemWebAdapters/samples/MvcCoreApp/appsettings.json
+++ b/src/SystemWebAdapters/samples/MvcCoreApp/appsettings.json
@@ -5,5 +5,25 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ReverseProxy": {
+    "Routes": {
+      "fallbackRoute": {
+        "ClusterId": "fallbackCluster",
+        "Order": "1",
+        "Match": {
+          "Path": "{**catch-all}"
+        }
+      }
+    },
+    "Clusters": {
+      "fallbackCluster": {
+        "Destinations": {
+          "fallbackApp": {
+            "Address": ""
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/SystemWebAdapters/src/Adapters/MigrationWebApplicationOptions.cs
+++ b/src/SystemWebAdapters/src/Adapters/MigrationWebApplicationOptions.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace System.Web.Adapters;
+
+public class MigrationWebApplicationOptions
+{
+#if NET6_0_OR_GREATER
+    public static WebApplicationOptions CreateWithRelativeContentRoute(string[] args)
+    {
+        if (args.Length > 0)
+        {
+            var config = new ConfigurationBuilder()
+                           .AddCommandLine(args)
+                           .Build();
+
+            if (config[WebHostDefaults.ContentRootKey] is { } contentRoot)
+            {
+                contentRoot = Path.GetFullPath(contentRoot);
+
+                var newArgs = config.AsEnumerable()
+                    .Where(t => t.Key != WebHostDefaults.ContentRootKey)
+                    .SelectMany(t => new[] { $"--{t.Key}", t.Value })
+                    .ToArray();
+
+                return new()
+                {
+                    Args = newArgs,
+                    ContentRootPath = contentRoot,
+                };
+            }
+        }
+
+        return new() { Args = args, };
+    }
+#endif
+}


### PR DESCRIPTION
The migration tooling when launched will have the content root by default show up as the framework app. The content root is passed in as a relative path which we need to handle before passing into WebApplicationBuilder
