### PR TITLE
Add ISystemWebAdapterBuilder to chain additional services

### DIFF
--- a/src/SystemWebAdapters/src/Adapters/ISystemWebAdapterBuilder.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISystemWebAdapterBuilder.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace System.Web.Adapters;
+
+public interface ISystemWebAdapterBuilder
+{
+    IServiceCollection Services { get; }
+}

--- a/src/SystemWebAdapters/src/Adapters/SystemWebAdaptersExtensions.cs
+++ b/src/SystemWebAdapters/src/Adapters/SystemWebAdaptersExtensions.cs
@@ -13,9 +13,18 @@ namespace System.Web.Adapters
 {
     public static class SystemWebAdaptersExtensions
     {
-        public static void AddSystemWebAdapters(this IServiceCollection services)
+        public static ISystemWebAdapterBuilder AddSystemWebAdapters(this IServiceCollection services)
         {
             services.AddHttpContextAccessor();
+
+            return new Builder(services);
+        }
+
+        public static ISystemWebAdapterBuilder AddSessionManager<TManager>(this ISystemWebAdapterBuilder builder)
+            where TManager : ISessionManager
+        {
+            builder.Services.AddSingleton<ISessionManager>();
+            return builder;
         }
 
         public static void UseSystemWebAdapters(this IApplicationBuilder app)
@@ -123,6 +132,16 @@ namespace System.Web.Adapters
             }
 
             throw new InvalidOperationException($"Feature {typeof(TFeature)} is not available");
+        }
+
+        private class Builder : ISystemWebAdapterBuilder
+        {
+            public Builder(IServiceCollection services)
+            {
+                Services = services;
+            }
+
+            public IServiceCollection Services { get; }
         }
     }
 }


### PR DESCRIPTION
This follows the pattern of IMvcBuilder so that additional System.Web adapter services (such as session) can be chained onto it.
