### PR TITLE
Use module instead of handler

### DIFF
--- a/src/SystemWebAdapters/samples/MvcApp/App_Start/RouteConfig.cs
+++ b/src/SystemWebAdapters/samples/MvcApp/App_Start/RouteConfig.cs
@@ -12,7 +12,6 @@ namespace MvcApp
         public static void RegisterRoutes(RouteCollection routes)
         {
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
-            routes.Ignore("session-state");
 
             routes.MapRoute(
                 name: "Default",

--- a/src/SystemWebAdapters/samples/MvcApp/Global.asax.cs
+++ b/src/SystemWebAdapters/samples/MvcApp/Global.asax.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 using System.Web.Adapters.SessionState;
 using System.Web.Http;
 using System.Web.Mvc;
@@ -19,7 +15,8 @@ namespace MvcApp
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
-            RemoteAppSessionStateHandler.Configure(ClassLibrary.SessionUtils.RegisterSessionKeys);
+
+            Application.ConfigureRemoteSession(ClassLibrary.SessionUtils.RegisterSessionKeys);
         }
     }
 }

--- a/src/SystemWebAdapters/samples/MvcApp/Web.config
+++ b/src/SystemWebAdapters/samples/MvcApp/Web.config
@@ -28,10 +28,10 @@
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
-			</dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
         <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
@@ -69,13 +69,15 @@
     </compilers>
   </system.codedom>
   <system.webServer>
+    <modules>
+      <remove name="SystemWebAdapterModule"/>
+      <add name="SystemWebAdapterModule" type="System.Web.Adapters.SystemWebAdapterModule, System.Web.Adapters" preCondition="managedHandler" />
+    </modules>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
       <remove name="OPTIONSVerbHandler"/>
       <remove name="TRACEVerbHandler"/>
-      <remove name="RemoteAppSessionStateHandler"/>
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
-      <add name="RemoteAppSessionStateHandler" path="session-state" verb="GET" type="System.Web.Adapters.SessionState.RemoteAppSessionStateHandler, System.Web.Adapters"/>
     </handlers>
   </system.webServer>
 </configuration>

--- a/src/SystemWebAdapters/samples/MvcCoreApp/Program.cs
+++ b/src/SystemWebAdapters/samples/MvcCoreApp/Program.cs
@@ -8,7 +8,7 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddSystemWebAdapters()
     .AddRemoteAppSession(options =>
     {
-        options.RemoteAppUrl = new Uri("https://localhost:44339/fallback/session-state");
+        options.RemoteApp = new("https://localhost:44339/fallback");
 
         ClassLibrary.SessionUtils.RegisterSessionKeys(options);
     });

--- a/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
@@ -61,7 +61,7 @@ internal class RemoteAppSessionStateManager : ISessionManager
             return null;
         }
 
-        var message = new HttpRequestMessage(HttpMethod.Get, options.RemoteAppUrl);
+        var message = new HttpRequestMessage(HttpMethod.Get, new Uri(options.RemoteApp, options.SessionEndpointPath));
 
         if (cookie is not null)
         {

--- a/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateOptions.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateOptions.cs
@@ -32,11 +32,16 @@ public class RemoteAppSessionStateOptions
     /// Gets or sets the remote app url
     /// </summary>
     [Required]
-    public Uri RemoteAppUrl { get; set; } = null!;
+    public Uri RemoteApp { get; set; } = null!;
 #endif
 
+#if NETCOREAPP3_1_OR_GREATER
+    [Required]
+#endif
+    public string SessionEndpointPath { get; set; } = "/fallback/adapter/session";
+
     /// <summary>
-    /// Gets or sets the cookie name that the ASP.NET framework app is expecting tol hold the session id
+    /// Gets or sets the cookie name that the ASP.NET framework app is expecting to hold the session id
     /// </summary>
 #if NETCOREAPP3_1_OR_GREATER
     [Required]

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -57,6 +57,11 @@ internal class SessionSerializer
 #if NET472
     public async ValueTask SerializeAsync(HttpSessionState state, Stream stream, CancellationToken token)
     {
+        if (state is null)
+        {
+            throw new ArgumentNullException(nameof(state));
+        }
+
         var values = new SessionValues();
 
         foreach (string key in state.Keys)

--- a/src/SystemWebAdapters/src/Content/Web.config.install.xdt
+++ b/src/SystemWebAdapters/src/Content/Web.config.install.xdt
@@ -3,33 +3,33 @@
 
   <!-- If system.webServer tag is absent -->
   <system.webServer xdt:Transform="InsertIfMissing">
-    <handlers>
-    </handlers>
+    <modules>
+    </modules>
   </system.webServer>
 
   <!-- If system.webServer tag is present, but handlers tag is absent -->
   <system.webServer>
-    <handlers xdt:Transform="InsertIfMissing">
-    </handlers>
+    <modules xdt:Transform="InsertIfMissing">
+    </modules>
   </system.webServer>
 
   <!-- If the handler is already present, the existing entry needs to be removed before inserting the new entry-->
   <system.webServer>
-    <handlers>
+    <modules>
       <remove xdt:Transform="Remove"
-          xdt:Locator="Condition(./@name='RemoteAppSessionStateHandler')" >
+          xdt:Locator="Condition(./@name='SystemWebAdapterModule')" >
       </remove>
       <add xdt:Transform="Remove"
-          xdt:Locator="Condition(./@name='RemoteAppSessionStateHandler')" >
+          xdt:Locator="Condition(./@name='SystemWebAdapterModule')" >
       </add>
-    </handlers>
+    </modules>
   </system.webServer>
 
   <!-- Inserting the handler -->
   <system.webServer>
-    <handlers>
-      <remove xdt:Transform="Insert" name="RemoteAppSessionStateHandler" />
-      <add xdt:Transform="Insert" name="RemoteAppSessionStateHandler" path="session-state" verb="GET" type="System.Web.Adapters.SessionState.RemoteAppSessionStateHandler, System.Web.Adapters"/>
-    </handlers>
+    <modules>
+      <remove xdt:Transform="Insert" name="SystemWebAdapterModule" />
+      <add xdt:Transform="Insert" name="SystemWebAdapterModule" type="System.Web.Adapters.SystemWebAdapterModule, System.Web.Adapters" preCondition="managedHandler" />
+    </modules>
   </system.webServer>
 </configuration>

--- a/src/SystemWebAdapters/src/Content/Web.config.uninstall.xdt
+++ b/src/SystemWebAdapters/src/Content/Web.config.uninstall.xdt
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <system.webServer>
-    <handlers>
+    <modules>
       <remove xdt:Transform="Remove"
-          xdt:Locator="Condition(./@name='RemoteAppSessionStateHandler')" >
+          xdt:Locator="Condition(./@name='SystemWebAdapterModule')" >
       </remove>
       <add xdt:Transform="Remove"
-          xdt:Locator="Condition(./@name='RemoteAppSessionStateHandler')" >
+          xdt:Locator="Condition(./@name='SystemWebAdapterModule')" >
       </add>
-    </handlers>
+    </modules>
   </system.webServer>
 </configuration>

--- a/src/SystemWebAdapters/src/Framework/SystemWebAdapterExtensions.cs
+++ b/src/SystemWebAdapters/src/Framework/SystemWebAdapterExtensions.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Web.Adapters.SessionState;
+
+public static class SystemWebAdapterExtensions
+{
+    private const string RemoteAppSessionOptions = "system-web-adapter-remote-app-session-options";
+
+    internal static RemoteAppSessionStateOptions? GetRemoteSessionOptions(this HttpApplicationState state)
+        => state.Get<RemoteAppSessionStateOptions>(RemoteAppSessionOptions);
+
+    public static HttpApplicationState ConfigureRemoteSession(this HttpApplicationState state, Action<RemoteAppSessionStateOptions> configure)
+        => state.ConfigureState(RemoteAppSessionOptions, configure);
+
+    private static T? Get<T>(this HttpApplicationState state, string name) => state[name] is T result ? result : default;
+
+    private static HttpApplicationState ConfigureState<T>(this HttpApplicationState state, string name, Action<T> configure)
+        where T : new()
+    {
+        if (state[name] is not T existing)
+        {
+            existing = new();
+            state[name] = existing;
+        }
+
+        configure(existing);
+
+        return state;
+    }
+}

--- a/src/SystemWebAdapters/src/Framework/SystemWebAdapterModule.cs
+++ b/src/SystemWebAdapters/src/Framework/SystemWebAdapterModule.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Web.Adapters.SessionState;
+using System.Web.SessionState;
+
+namespace System.Web.Adapters;
+
+public sealed class SystemWebAdapterModule : IHttpModule, IReadOnlySessionState
+{
+    public void Dispose()
+    {
+    }
+
+    public void Init(HttpApplication context)
+    {
+        RegisterRemoteSession(context);
+    }
+
+    private void RegisterRemoteSession(HttpApplication context)
+    {
+        if (context.Application.GetRemoteSessionOptions() is not { } options)
+        {
+            return;
+        }
+
+        var handler = new RemoteAppSessionStateHandler(options);
+
+        context.PostMapRequestHandler += MapRemoteSessionHandler;
+
+        void MapRemoteSessionHandler(object sender, EventArgs e)
+        {
+            var context = ((HttpApplication)sender).Context;
+
+            if (string.Equals(context.Request.Path, options.SessionEndpointPath))
+            {
+                context.SetSessionStateBehavior(SessionStateBehavior.ReadOnly);
+                context.Handler = handler;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This replaces the HttpHandler with a module so that we can have a central point to hook into various aspects of the framework app to support the adapters.

The remote session handler is now managed by the module so a user just needs to configure it and it will run rather than needing to configure it in web.config.