### PR TITLE
Enable package validation

### DIFF
--- a/src/SystemWebAdapters/src/Adapters/ISessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISessionState.cs
@@ -16,7 +16,7 @@ public interface ISessionState : IAsyncDisposable
 
     bool IsReadOnly { get; }
 
-    int TimeOut { get; set; }
+    int Timeout { get; set; }
 
     bool IsNewSession { get; }
 

--- a/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
@@ -102,7 +102,7 @@ internal class RemoteAppSessionStateManager : ISessionManager
 
         public bool IsReadOnly => true;
 
-        public int TimeOut { get; set; } = 0;
+        public int Timeout { get; set; } = 0;
 
         public bool IsNewSession => true;
 

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -74,7 +74,7 @@ internal class SessionSerializer
             IsNewSession = state.IsNewSession,
             IsReadOnly = state.IsReadOnly,
             SessionID = state.SessionID,
-            TimeOut = state.Timeout,
+            Timeout = state.Timeout,
             Values = values
         };
 
@@ -169,7 +169,7 @@ internal class SessionSerializer
 
         public int Count => Values.Count;
 
-        public int TimeOut { get; set; }
+        public int Timeout { get; set; }
 
         public bool IsNewSession { get; set; }
 

--- a/src/SystemWebAdapters/src/Caching/Cache.cs
+++ b/src/SystemWebAdapters/src/Caching/Cache.cs
@@ -3,7 +3,7 @@
 
 namespace System.Web.Caching
 {
-    public class Cache
+    public sealed class Cache
     {
         public static readonly DateTime NoAbsoluteExpiration = DateTime.MaxValue;
 

--- a/src/SystemWebAdapters/src/HttpContext.cs
+++ b/src/SystemWebAdapters/src/HttpContext.cs
@@ -48,7 +48,7 @@ public class HttpContext : IServiceProvider
 
     public HttpSessionState? Session => _context.Features.Get<HttpSessionState>();
 
-    public object? GetService(Type service)
+    object? IServiceProvider.GetService(Type service)
     {
         if (service == typeof(HttpRequest))
         {

--- a/src/SystemWebAdapters/src/HttpCookie.cs
+++ b/src/SystemWebAdapters/src/HttpCookie.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace System.Web;
 
-public class HttpCookie
+public sealed class HttpCookie
 {
     // If the .Values collection hasn't been accessed, this will remain a string. However, once .Values is accessed,
     // this will become a HttpValueCollection. If .ToString is called on it, it will reconsistute the full string

--- a/src/SystemWebAdapters/src/HttpResponse.cs
+++ b/src/SystemWebAdapters/src/HttpResponse.cs
@@ -192,8 +192,6 @@ namespace System.Web
             }
         }
 
-        public void Abort() => _response.HttpContext.Abort();
-
         [return: NotNullIfNotNull("response")]
         public static implicit operator HttpResponse?(HttpResponseCore? response) => response?.GetAdapter();
 

--- a/src/SystemWebAdapters/src/HttpResponseBase.cs
+++ b/src/SystemWebAdapters/src/HttpResponseBase.cs
@@ -46,11 +46,7 @@ namespace System.Web
 
         public virtual Stream OutputStream => throw new NotImplementedException();
 
-        public virtual HttpCookieCollection Cookies
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
+        public virtual HttpCookieCollection Cookies => throw new NotImplementedException();
 
         public virtual bool SuppressContent
         {
@@ -89,7 +85,5 @@ namespace System.Web
         public void Clear() => throw new NotImplementedException();
 
         public void ClearContent() => throw new NotImplementedException();
-
-        public virtual void Abort() => throw new NotImplementedException();
     }
 }

--- a/src/SystemWebAdapters/src/HttpResponseWrapper.cs
+++ b/src/SystemWebAdapters/src/HttpResponseWrapper.cs
@@ -16,8 +16,6 @@ namespace System.Web
             _response = response;
         }
 
-        public override void Abort() => _response.Abort();
-
         public override void AddHeader(string name, string value) => _response.AddHeader(name, value);
 
         public override string? ContentType

--- a/src/SystemWebAdapters/src/Ref.Standard.cs
+++ b/src/SystemWebAdapters/src/Ref.Standard.cs
@@ -18,7 +18,7 @@ namespace System.Web
         public System.Web.HttpServerUtility Server { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public System.Web.SessionState.HttpSessionState Session { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public object GetService(System.Type service) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        object System.IServiceProvider.GetService(System.Type service) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpContextBase : System.IServiceProvider
     {
@@ -40,7 +40,7 @@ namespace System.Web
         public override System.Web.HttpSessionStateBase Session { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
     }
-    public partial class HttpCookie
+    public sealed partial class HttpCookie
     {
         public HttpCookie(string name) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public HttpCookie(string name, string value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
@@ -175,7 +175,6 @@ namespace System.Web
         public string StatusDescription { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public bool SuppressContent { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public bool TrySkipIisCustomErrors { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public void Abort() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void AddHeader(string name, string value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void AppendHeader(string name, string value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Clear() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
@@ -192,7 +191,7 @@ namespace System.Web
         public string Charset { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual string ContentType { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public virtual System.Web.HttpCookieCollection Cookies { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public virtual System.Web.HttpCookieCollection Cookies { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection Headers { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual bool IsClientConnected { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual System.IO.TextWriter Output { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
@@ -201,7 +200,6 @@ namespace System.Web
         public virtual string StatusDescription { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual bool SuppressContent { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual bool TrySkipIisCustomErrors { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public virtual void Abort() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void AddHeader(string name, string value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void AppendHeader(string name, string value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Clear() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
@@ -226,7 +224,6 @@ namespace System.Web
         public override string StatusDescription { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override bool SuppressContent { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override bool TrySkipIisCustomErrors { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public override void Abort() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void AddHeader(string name, string value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void SetCookie(System.Web.HttpCookie cookie) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void Write(char ch) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
@@ -261,7 +258,7 @@ namespace System.Web
         public virtual bool IsReadOnly { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual object this[string name] { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual string SessionID { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public virtual int TimeOut { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public virtual int Timeout { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual void Abandon() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void Add(string name, object value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void Clear() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
@@ -276,7 +273,7 @@ namespace System.Web
         public override bool IsReadOnly { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override object this[string name] { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override string SessionID { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public override int TimeOut { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public override int Timeout { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override void Abandon() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void Add(string name, object value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void Clear() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
@@ -292,7 +289,7 @@ namespace System.Web
 }
 namespace System.Web.Caching
 {
-    public partial class Cache
+    public sealed partial class Cache
     {
         public static readonly System.DateTime NoAbsoluteExpiration;
         public static readonly System.TimeSpan NoSlidingExpiration;
@@ -313,7 +310,7 @@ namespace System.Web.SessionState
         public bool IsReadOnly { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public object this[string name] { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public string SessionID { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
-        public int TimeOut { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public int Timeout { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public void Abandon() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Add(string name, object value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Clear() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}

--- a/src/SystemWebAdapters/src/SessionState/HttpSessionState.cs
+++ b/src/SystemWebAdapters/src/SessionState/HttpSessionState.cs
@@ -22,10 +22,10 @@ public class HttpSessionState
 
     public bool IsNewSession { get; }
 
-    public int TimeOut
+    public int Timeout
     {
-        get => _container.TimeOut;
-        set => _container.TimeOut = value;
+        get => _container.Timeout;
+        set => _container.Timeout = value;
     }
 
     public void Abandon() => _container.Abandon();

--- a/src/SystemWebAdapters/src/SessionState/HttpSessionStateBase.cs
+++ b/src/SystemWebAdapters/src/SessionState/HttpSessionStateBase.cs
@@ -11,7 +11,7 @@ public abstract class HttpSessionStateBase
 
     public virtual bool IsReadOnly => throw new NotImplementedException();
 
-    public virtual int TimeOut
+    public virtual int Timeout
     {
         get => throw new NotImplementedException();
         set => throw new NotImplementedException();

--- a/src/SystemWebAdapters/src/SessionState/HttpSessionStateWrapper.cs
+++ b/src/SystemWebAdapters/src/SessionState/HttpSessionStateWrapper.cs
@@ -22,10 +22,10 @@ public class HttpSessionStateWrapper : HttpSessionStateBase
 
     public override bool IsNewSession => _session.IsNewSession;
 
-    public override int TimeOut
+    public override int Timeout
     {
-        get => _session.TimeOut;
-        set => _session.TimeOut = value;
+        get => _session.Timeout;
+        set => _session.Timeout = value;
     }
 
     public override void Abandon() => _session.Abandon();

--- a/src/SystemWebAdapters/src/System.Web.Adapters.csproj
+++ b/src/SystemWebAdapters/src/System.Web.Adapters.csproj
@@ -8,6 +8,9 @@
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
     <RootNamespace>System.Web</RootNamespace>
+
+    <!-- This will validate that the package will unify correctly with System.Web.dll -->
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SystemWebAdapters/test/Adapters/SessionState/SessionStateSerialization.cs
+++ b/src/SystemWebAdapters/test/Adapters/SessionState/SessionStateSerialization.cs
@@ -70,7 +70,7 @@ public class SessionStateSerialization
     ""Key1"": 5
   },
   ""Count"": 1,
-  ""TimeOut"": 0,
+  ""Timeout"": 0,
   ""IsNewSession"": false,
   ""IsAbandoned"": false
 }";

--- a/src/SystemWebAdapters/test/HttpContextTests.cs
+++ b/src/SystemWebAdapters/test/HttpContextTests.cs
@@ -79,13 +79,14 @@ namespace System.Web.Adapters.Tests
             coreContext.Features.Set(new HttpSessionState(new Mock<ISessionState>().Object));
 
             var context = new HttpContext(coreContext);
+            var provider = (IServiceProvider)context;
 
-            Assert.Same(context.Request, context.GetService(typeof(HttpRequest)));
-            Assert.Same(context.Response, context.GetService(typeof(HttpResponse)));
-            Assert.Same(context.Server, context.GetService(typeof(HttpServerUtility)));
-            Assert.Same(context.Session, context.GetService(typeof(HttpSessionState)));
+            Assert.Same(context.Request, provider.GetService(typeof(HttpRequest)));
+            Assert.Same(context.Response, provider.GetService(typeof(HttpResponse)));
+            Assert.Same(context.Server, provider.GetService(typeof(HttpServerUtility)));
+            Assert.Same(context.Session, provider.GetService(typeof(HttpSessionState)));
 
-            Assert.Null(context.GetService(typeof(HttpContext)));
+            Assert.Null(provider.GetService(typeof(HttpContext)));
         }
 
         [Fact]

--- a/src/SystemWebAdapters/test/HttpResponseTests.cs
+++ b/src/SystemWebAdapters/test/HttpResponseTests.cs
@@ -330,24 +330,6 @@ public class HttpResponseTests
         body.Verify(b => b.SetLength(0), Times.Once);
     }
 
-    [Fact]
-    public void Abort()
-    {
-        // Arrange
-        var context = new Mock<HttpContextCore>();
-
-        var responseCore = new Mock<HttpResponseCore>();
-        responseCore.Setup(r => r.HttpContext).Returns(context.Object);
-
-        var response = new HttpResponse(responseCore.Object);
-
-        // Act
-        response.Abort();
-
-        // Assert
-        context.Verify(f => f.Abort(), Times.Once);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
This change enables the SDK package validation to ensure we have the correct method signatures on the various builds. This will help catch regressions to APIs that are supposed to unify with .NET Framework. As part of this, a number of issues were flagged which are fixed with this change as well.