### PR TITLE
Add proxy header support for adapters

### DIFF
--- a/src/SystemWebAdapters/samples/MvcApp/Global.asax.cs
+++ b/src/SystemWebAdapters/samples/MvcApp/Global.asax.cs
@@ -1,4 +1,4 @@
-using System.Web.Adapters.SessionState;
+using System.Web.Adapters;
 using System.Web.Http;
 using System.Web.Mvc;
 using System.Web.Optimization;
@@ -16,7 +16,9 @@ namespace MvcApp
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
 
-            Application.ConfigureRemoteSession(ClassLibrary.SessionUtils.RegisterSessionKeys);
+            Application.AddSystemWebAdapters()
+                .AddProxySupport(options => options.UseForwardedHeaders = true)
+                .AddRemoteSession(ClassLibrary.SessionUtils.RegisterSessionKeys);
         }
     }
 }

--- a/src/SystemWebAdapters/samples/MvcApp/Views/Home/Contact.cshtml
+++ b/src/SystemWebAdapters/samples/MvcApp/Views/Home/Contact.cshtml
@@ -1,17 +1,22 @@
-﻿@{
+@{
     ViewBag.Title = "Contact";
 }
 <h2>@ViewBag.Title.</h2>
 <h3>@ViewBag.Message</h3>
+
+<p>
+    <b>Url:</b>&nbsp;@Context.Request.Url
+    <br />
+    <b>RawUrl:</b>&nbsp;@Context.Request.RawUrl
+    <br />
+    <b>REMOTE_ADDR:</b>&nbsp;@Context.Request.ServerVariables["REMOTE_ADDR"]
+    <br />
+    <b>REMOTE_HOST</b>&nbsp;@Context.Request.ServerVariables["REMOTE_HOST"]
+</p>
 
 <address>
     One Microsoft Way<br />
     Redmond, WA 98052-6399<br />
     <abbr title="Phone">P:</abbr>
     425.555.0100
-</address>
-
-<address>
-    <strong>Support:</strong>   <a href="mailto:Support@example.com">Support@example.com</a><br />
-    <strong>Marketing:</strong> <a href="mailto:Marketing@example.com">Marketing@example.com</a>
 </address>

--- a/src/SystemWebAdapters/samples/MvcApp/Views/Shared/_Layout.cshtml
+++ b/src/SystemWebAdapters/samples/MvcApp/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -23,6 +23,7 @@
                     <li>@Html.ActionLink("Home", "Index", "Home")</li>
                     <li>@Html.ActionLink("About", "About", "Home")</li>
                     <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
+                    <li>@Html.ActionLink("Privacy", "Privacy", "Home")</li>
                 </ul>
             </div>
         </div>

--- a/src/SystemWebAdapters/samples/MvcCoreApp/Program.cs
+++ b/src/SystemWebAdapters/samples/MvcCoreApp/Program.cs
@@ -8,7 +8,7 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddSystemWebAdapters()
     .AddRemoteAppSession(options =>
     {
-        options.RemoteApp = new("https://localhost:44339/fallback");
+        options.RemoteApp = new(builder.Configuration["ReverseProxy:Clusters:fallbackCluster:Destinations:fallbackApp:Address"]);
 
         ClassLibrary.SessionUtils.RegisterSessionKeys(options);
     });

--- a/src/SystemWebAdapters/samples/MvcCoreApp/Views/Shared/_Layout.cshtml
+++ b/src/SystemWebAdapters/samples/MvcCoreApp/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -24,6 +24,9 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Contact">Contact</a>
                         </li>
                     </ul>
                 </div>

--- a/src/SystemWebAdapters/src/Adapters/ISystemWebAdapterBuilder.Framework.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISystemWebAdapterBuilder.Framework.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace System.Web.Adapters;
+
+public interface ISystemWebAdapterBuilder
+{
+    ICollection<IHttpModule> Modules { get; }
+}

--- a/src/SystemWebAdapters/src/Adapters/Modules/ProxyHeaderModule.Framework.cs
+++ b/src/SystemWebAdapters/src/Adapters/Modules/ProxyHeaderModule.Framework.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Web.Adapters;
+
+internal class ProxyHeaderModule : IHttpModule
+{
+    private readonly ProxyOptions _options;
+
+    public ProxyHeaderModule(ProxyOptions options)
+    {
+        _options = options;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public void Init(HttpApplication context)
+    {
+        if (_options.UseForwardedHeaders)
+        {
+            context.BeginRequest += static (s, e) => UseHeaders(((HttpApplication)s).Context.Request);
+        }
+        else
+        {
+            if (_options.ServerName is null)
+            {
+                throw new InvalidOperationException("Server name must be set for proxy options.");
+            }
+
+            context.BeginRequest += (s, e) => UseOptions(((HttpApplication)s).Context.Request);
+        }
+    }
+
+    private void UseOptions(HttpRequest request)
+    {
+        UseForwardedFor(request);
+
+        request.ServerVariables.Set("SERVER_NAME", _options.ServerName);
+        request.ServerVariables.Set("SERVER_PORT", _options.ServerPortString);
+        request.ServerVariables.Set("SERVER_PROTOCOL", _options.Scheme);
+    }
+
+    private static void UseHeaders(HttpRequest request)
+    {
+        UseForwardedFor(request);
+
+        if (request.Headers["x-forwarded-host"] is { } host)
+        {
+            var value = new ProtoHost(host);
+
+            request.ServerVariables.Set("SERVER_NAME", value.ServerName);
+            request.ServerVariables.Set("SERVER_PORT", value.Port);
+        }
+
+        if (request.Headers["x-forwarded-proto"] is { } proto)
+        {
+            request.ServerVariables.Set("SERVER_PROTOCOL", proto);
+        }
+    }
+
+    private static void UseForwardedFor(HttpRequest request)
+    {
+        if (request.Headers["x-forwarded-for"] is { } remote)
+        {
+            request.ServerVariables.Set("REMOTE_ADDR", remote);
+            request.ServerVariables.Set("REMOTE_HOST", remote);
+        }
+    }
+
+    private struct ProtoHost
+    {
+        public ProtoHost(string host)
+        {
+            var idx = host.IndexOf(":");
+
+            if (idx < 0)
+            {
+                ServerName = host;
+                Port = "80";
+            }
+            else
+            {
+                ServerName = host.Substring(0, idx);
+                Port = host.Substring(idx + 1);
+            }
+        }
+
+        public string ServerName { get; }
+
+        public string Port { get; }
+    }
+}

--- a/src/SystemWebAdapters/src/Adapters/Modules/ProxyHeaderModule.Framework.cs
+++ b/src/SystemWebAdapters/src/Adapters/Modules/ProxyHeaderModule.Framework.cs
@@ -48,7 +48,7 @@ internal class ProxyHeaderModule : IHttpModule
 
         if (request.Headers["x-forwarded-host"] is { } host)
         {
-            var value = new ProtoHost(host);
+            var value = new ForwardedHost(host);
 
             request.ServerVariables.Set("SERVER_NAME", value.ServerName);
             request.ServerVariables.Set("SERVER_PORT", value.Port);
@@ -69,16 +69,16 @@ internal class ProxyHeaderModule : IHttpModule
         }
     }
 
-    private struct ProtoHost
+    private struct ForwardedHost
     {
-        public ProtoHost(string host)
+        public ForwardedHost(string host)
         {
             var idx = host.IndexOf(":");
 
             if (idx < 0)
             {
                 ServerName = host;
-                Port = "80";
+                Port = "443";
             }
             else
             {

--- a/src/SystemWebAdapters/src/Adapters/Modules/ProxyHeaderModule.Framework.cs
+++ b/src/SystemWebAdapters/src/Adapters/Modules/ProxyHeaderModule.Framework.cs
@@ -51,7 +51,11 @@ internal class ProxyHeaderModule : IHttpModule
             var value = new ForwardedHost(host);
 
             request.ServerVariables.Set("SERVER_NAME", value.ServerName);
-            request.ServerVariables.Set("SERVER_PORT", value.Port);
+
+            if (value.Port is { })
+            {
+                request.ServerVariables.Set("SERVER_PORT", value.Port);
+            }
         }
 
         if (request.Headers["x-forwarded-proto"] is { } proto)
@@ -78,7 +82,7 @@ internal class ProxyHeaderModule : IHttpModule
             if (idx < 0)
             {
                 ServerName = host;
-                Port = "443";
+                Port = null;
             }
             else
             {
@@ -89,6 +93,6 @@ internal class ProxyHeaderModule : IHttpModule
 
         public string ServerName { get; }
 
-        public string Port { get; }
+        public string? Port { get; }
     }
 }

--- a/src/SystemWebAdapters/src/Adapters/Modules/ProxyOptions.Framework.cs
+++ b/src/SystemWebAdapters/src/Adapters/Modules/ProxyOptions.Framework.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Web.Adapters;
+
+public class ProxyOptions
+{
+    private string? _port;
+
+    /// <summary>
+    /// Gets or sets whether the X-Forwarded-* headers should be used for incoming requests.
+    /// </summary>
+    public bool UseForwardedHeaders { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server name.
+    /// </summary>
+    public string? ServerName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server port.
+    /// </summary>
+    public int ServerPort { get; set; } = 443;
+
+    /// <summary>
+    /// Gets or sets the scheme. 
+    /// </summary>
+    public string Scheme { get; set; } = "https";
+
+    internal string ServerPortString => _port ??= ServerPort.ToString();
+}

--- a/src/SystemWebAdapters/src/Adapters/Modules/RemoteSessionModule.Framework.cs
+++ b/src/SystemWebAdapters/src/Adapters/Modules/RemoteSessionModule.Framework.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Web.Adapters.SessionState;
+using System.Web.SessionState;
+
+namespace System.Web.Adapters;
+
+internal sealed class RemoteSessionModule : IHttpModule
+{
+    private readonly RemoteAppSessionStateOptions _options;
+
+    public RemoteSessionModule(RemoteAppSessionStateOptions options)
+    {
+        _options = options;
+    }
+
+    public void Init(HttpApplication context)
+    {
+        var handler = new RemoteAppSessionStateHandler(_options);
+
+        context.PostMapRequestHandler += MapRemoteSessionHandler;
+
+        void MapRemoteSessionHandler(object sender, EventArgs e)
+        {
+            var context = ((HttpApplication)sender).Context;
+
+            if (string.Equals(context.Request.Path, _options.SessionEndpointPath))
+            {
+                context.SetSessionStateBehavior(SessionStateBehavior.ReadOnly);
+                context.Handler = handler;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/SystemWebAdapters/src/Content/Web.config.install.xdt
+++ b/src/SystemWebAdapters/src/Content/Web.config.install.xdt
@@ -7,13 +7,13 @@
     </modules>
   </system.webServer>
 
-  <!-- If system.webServer tag is present, but handlers tag is absent -->
+  <!-- If system.webServer tag is present, but modules tag is absent -->
   <system.webServer>
     <modules xdt:Transform="InsertIfMissing">
     </modules>
   </system.webServer>
 
-  <!-- If the handler is already present, the existing entry needs to be removed before inserting the new entry-->
+  <!-- If the modules tag is already present, the existing entry needs to be removed before inserting the new entry -->
   <system.webServer>
     <modules>
       <remove xdt:Transform="Remove"
@@ -25,7 +25,7 @@
     </modules>
   </system.webServer>
 
-  <!-- Inserting the handler -->
+  <!-- Insert the module -->
   <system.webServer>
     <modules>
       <remove xdt:Transform="Insert" name="SystemWebAdapterModule" />


### PR DESCRIPTION
This change adds a module for the framework app that will handle proxy values. As part of this change, the SystemWebAdapter module will load any registered modules so that we can keep them specific to the feature they enable.
