### PR TITLE
Add SessionBehavior to enable loading session on demand

### DIFF
--- a/src/SystemWebAdapters/src/Adapters/ISessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISessionState.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.SessionState;
@@ -39,7 +39,7 @@ public interface ISessionState : IDisposable
 
     void Clear();
 
-    IEnumerator GetEnumerator();
+    IEnumerable<string> Keys { get; }
 
     ValueTask CommitAsync(CancellationToken token);
 }

--- a/src/SystemWebAdapters/src/Adapters/ISessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISessionState.cs
@@ -11,7 +11,7 @@ namespace System.Web.Adapters;
 /// <summary>
 /// Represents the state of a session and is used to create a <see cref="HttpSessionState"/> . Disposing the state will handle any writing that may need to be done.
 /// </summary>
-public interface ISessionState : ICollection, IDisposable
+public interface ISessionState : IDisposable
 {
     string SessionID { get; }
 
@@ -21,15 +21,25 @@ public interface ISessionState : ICollection, IDisposable
 
     bool IsNewSession { get; }
 
+    int Count { get; }
+
+    bool IsSynchronized { get; }
+
+    object SyncRoot { get; }
+
     void Abandon();
 
     object? this[string name] { get; set; }
 
     void Add(string name, object value);
 
+    void CopyTo(Array array, int index);
+
     void Remove(string name);
 
     void Clear();
+
+    IEnumerator GetEnumerator();
 
     ValueTask CommitAsync(CancellationToken token);
 }

--- a/src/SystemWebAdapters/src/Adapters/ISessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISessionState.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web.SessionState;
 
 namespace System.Web.Adapters;
@@ -8,7 +10,7 @@ namespace System.Web.Adapters;
 /// <summary>
 /// Represents the state of a session and is used to create a <see cref="HttpSessionState"/> . Disposing the state will handle any writing that may need to be done.
 /// </summary>
-public interface ISessionState : IAsyncDisposable
+public interface ISessionState : IDisposable
 {
     string SessionID { get; }
 
@@ -29,4 +31,6 @@ public interface ISessionState : IAsyncDisposable
     void Remove(string name);
 
     void Clear();
+
+    ValueTask CommitAsync(CancellationToken token);
 }

--- a/src/SystemWebAdapters/src/Adapters/ISessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/ISessionState.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.SessionState;
@@ -10,11 +11,9 @@ namespace System.Web.Adapters;
 /// <summary>
 /// Represents the state of a session and is used to create a <see cref="HttpSessionState"/> . Disposing the state will handle any writing that may need to be done.
 /// </summary>
-public interface ISessionState : IDisposable
+public interface ISessionState : ICollection, IDisposable
 {
     string SessionID { get; }
-
-    int Count { get; }
 
     bool IsReadOnly { get; }
 

--- a/src/SystemWebAdapters/src/Adapters/SessionAttribute.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionAttribute.cs
@@ -6,7 +6,7 @@ namespace System.Web.Adapters;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public sealed class SessionAttribute : Attribute, ISessionMetadata
 {
-    public bool IsEnabled { get; set; } = true;
+    public SessionBehavior Behavior { get; set; } = SessionBehavior.Eager;
 
     public bool IsReadOnly { get; set; } = true;
 }

--- a/src/SystemWebAdapters/src/Adapters/SessionBehavior.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionBehavior.cs
@@ -3,9 +3,11 @@
 
 namespace System.Web.Adapters;
 
-public interface ISessionMetadata
+public enum SessionBehavior
 {
-    SessionBehavior Behavior { get; }
+    None,
+    Eager,
 
-    bool IsReadOnly { get; }
+    [Obsolete("This will enable session on the endpoint but will resort to async over sync behavior")]
+    OnDemand,
 }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/DelegatingSessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/DelegatingSessionState.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,6 +31,10 @@ public abstract class DelegatingSessionState : ISessionState
 
     public virtual bool IsNewSession => State.IsNewSession;
 
+    public virtual bool IsSynchronized => State.IsSynchronized;
+
+    public virtual object SyncRoot => State.SyncRoot;
+
     public virtual void Abandon() => State.Abandon();
 
     public virtual void Add(string name, object value) => State.Add(name, value);
@@ -49,4 +54,8 @@ public abstract class DelegatingSessionState : ISessionState
     public virtual void Remove(string name) => State.Remove(name);
 
     public virtual ValueTask CommitAsync(CancellationToken token) => State.CommitAsync(token);
+
+    public virtual void CopyTo(Array array, int index) => State.CopyTo(array, index);
+
+    public virtual IEnumerator GetEnumerator() => State.GetEnumerator();
 }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/DelegatingSessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/DelegatingSessionState.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Web.Adapters;
+
+public abstract class DelegatingSessionState : ISessionState
+{
+    protected DelegatingSessionState()
+    {
+    }
+
+    protected abstract ISessionState State { get; }
+
+    public virtual object? this[string name]
+    {
+        get => State[name];
+        set => State[name] = value;
+    }
+
+    public virtual string SessionID => State.SessionID;
+
+    public virtual int Count => State.Count;
+
+    public virtual bool IsReadOnly => State.IsReadOnly;
+
+    public virtual int Timeout { get => State.Timeout; set => State.Timeout = value; }
+
+    public virtual bool IsNewSession => State.IsNewSession;
+
+    public virtual void Abandon() => State.Abandon();
+
+    public virtual void Add(string name, object value) => State.Add(name, value);
+
+    public virtual void Clear() => State.Clear();
+
+    public void Dispose() => Dispose(true);
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            State.Dispose();
+        }
+    }
+
+    public virtual void Remove(string name) => State.Remove(name);
+
+    public virtual ValueTask CommitAsync(CancellationToken token) => State.CommitAsync(token);
+}

--- a/src/SystemWebAdapters/src/Adapters/SessionState/DelegatingSessionState.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/DelegatingSessionState.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -57,5 +57,5 @@ public abstract class DelegatingSessionState : ISessionState
 
     public virtual void CopyTo(Array array, int index) => State.CopyTo(array, index);
 
-    public virtual IEnumerator GetEnumerator() => State.GetEnumerator();
+    public virtual IEnumerable<string> Keys => State.Keys;
 }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
@@ -107,6 +108,10 @@ internal class RemoteAppSessionStateManager : ISessionManager
 
         public bool IsNewSession => true;
 
+        public bool IsSynchronized => false;
+
+        public object SyncRoot => ((ICollection)_state).SyncRoot;
+
         public void Abandon()
         {
         }
@@ -117,9 +122,19 @@ internal class RemoteAppSessionStateManager : ISessionManager
 
         public ValueTask CommitAsync(CancellationToken token) => default;
 
+        public void CopyTo(Array array, int index)
+        {
+            foreach (var item in _state.Keys)
+            {
+                array.SetValue(item, index);
+            }
+        }
+
         public void Dispose()
         {
         }
+
+        public IEnumerator GetEnumerator() => _state.Keys.GetEnumerator();
 
         public void Remove(string name) => _state.Remove(name);
     }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
@@ -134,7 +134,7 @@ internal class RemoteAppSessionStateManager : ISessionManager
         {
         }
 
-        public IEnumerator GetEnumerator() => _state.Keys.GetEnumerator();
+        public IEnumerable<string> Keys => _state.Keys;
 
         public void Remove(string name) => _state.Remove(name);
     }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/RemoteAppSessionStateManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -114,7 +115,11 @@ internal class RemoteAppSessionStateManager : ISessionManager
 
         public void Clear() => _state.Clear();
 
-        public ValueTask DisposeAsync() => default;
+        public ValueTask CommitAsync(CancellationToken token) => default;
+
+        public void Dispose()
+        {
+        }
 
         public void Remove(string name) => _state.Remove(name);
     }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Specialized;
 using System.Collections;
+using System.Linq;
 
 #if NETCOREAPP3_1_OR_GREATER
 using System.Web.Adapters;
@@ -133,15 +134,11 @@ internal class SessionSerializer
         {
             writer.WriteStartObject();
 
-            foreach (var (key, value) in session.KeyValues)
+            foreach (var key in session.Keys)
             {
                 writer.WritePropertyName(key);
 
-                if (value is null)
-                {
-                    writer.WriteNullValue();
-                }
-                else
+                if (session[key] is { } value)
                 {
                     if (!_map.TryGetValue(key, out var type))
                     {
@@ -149,6 +146,10 @@ internal class SessionSerializer
                     }
 
                     JsonSerializer.Serialize(writer, value, type, options);
+                }
+                else
+                {
+                    writer.WriteNullValue();
                 }
             }
 
@@ -187,6 +188,9 @@ internal class SessionSerializer
 
         public bool IsAbandoned { get; set; }
 
+        [JsonIgnore]
+        public IEnumerable<string> Keys => _values?.Keys ?? Enumerable.Empty<string>();
+
         public bool IsSynchronized => ((ICollection)Values).IsSynchronized;
 
         public object SyncRoot => ((ICollection)Values).SyncRoot;
@@ -195,9 +199,9 @@ internal class SessionSerializer
 
         public void Add(string name, object value) => Values.Add(name, value);
 
-        public void Clear() => Values.Clear();
+        public void Clear() => _values?.Clear();
 
-        public void Remove(string name) => Values.Remove(name);
+        public void Remove(string name) => _values?.Remove(name);
 
         public ValueTask CommitAsync(CancellationToken token) => default;
 
@@ -218,16 +222,13 @@ internal class SessionSerializer
 
         public void Remove(string key) => BaseRemove(key);
 
-        public IEnumerable<(string, object?)> KeyValues
+        public new IEnumerable<string> Keys
         {
             get
             {
-                foreach (string? key in Keys)
+                foreach (var key in base.Keys)
                 {
-                    if (key is not null)
-                    {
-                        yield return (key, BaseGet(key));
-                    }
+                    yield return (string)key!;
                 }
             }
         }

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -181,9 +181,13 @@ internal class SessionSerializer
 
         public void Clear() => Values.Clear();
 
-        public ValueTask DisposeAsync() => default;
-
         public void Remove(string name) => Values.Remove(name);
+
+        public ValueTask CommitAsync(CancellationToken token) => default;
+
+        public void Dispose()
+        {
+        }
     }
 
     private class SessionValues : NameObjectCollectionBase

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -34,6 +34,10 @@ internal class SessionSerializer
     {
         Options = new JsonSerializerOptions
         {
+#if !NETCOREAPP3_1
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+#endif
+            AllowTrailingCommas = true,
             IgnoreReadOnlyProperties = true,
             Converters =
             {
@@ -157,6 +161,8 @@ internal class SessionSerializer
         : ISessionState
 #endif
     {
+        private SessionValues? _values;
+
         public object? this[string name]
         {
             get => Values[name];
@@ -167,7 +173,11 @@ internal class SessionSerializer
 
         public bool IsReadOnly { get; set; }
 
-        public SessionValues Values { get; set; } = null!;
+        public SessionValues Values
+        {
+            get => _values ??= new();
+            set => _values = value;
+        }
 
         public int Count => Values.Count;
 

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -34,6 +34,7 @@ internal class SessionSerializer
     {
         Options = new JsonSerializerOptions
         {
+            IgnoreReadOnlyProperties = true,
             Converters =
             {
                 new SerializedSessionConverter(map),

--- a/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
+++ b/src/SystemWebAdapters/src/Adapters/SessionState/SessionSerializer.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Specialized;
+using System.Collections;
 
 #if NETCOREAPP3_1_OR_GREATER
 using System.Web.Adapters;
@@ -175,6 +176,10 @@ internal class SessionSerializer
 
         public bool IsAbandoned { get; set; }
 
+        public bool IsSynchronized => ((ICollection)Values).IsSynchronized;
+
+        public object SyncRoot => ((ICollection)Values).SyncRoot;
+
         public void Abandon() => IsAbandoned = true;
 
         public void Add(string name, object value) => Values.Add(name, value);
@@ -188,6 +193,10 @@ internal class SessionSerializer
         public void Dispose()
         {
         }
+
+        public void CopyTo(Array array, int index) => ((ICollection)Values).CopyTo(array, index);
+
+        public IEnumerator GetEnumerator() => Values.GetEnumerator();
     }
 
     private class SessionValues : NameObjectCollectionBase

--- a/src/SystemWebAdapters/src/ExcludedApis.txt
+++ b/src/SystemWebAdapters/src/ExcludedApis.txt
@@ -12,6 +12,8 @@ T:System.Web.Adapters.ISessionMetadata
 T:System.Web.Adapters.ISessionManager
 T:System.Web.Adapters.RemoteAppSessionStateExtensions
 T:System.Web.Adapters.SessionState.RemoteAppSessionStateOptions
+T:System.Web.Adapters.DelegatingSessionState
+T:System.Web.Adapters.SessionBehavior
 
 # Buffering
 T:System.Web.Adapters.BufferResponseStreamAttribute

--- a/src/SystemWebAdapters/src/Ref.Standard.cs
+++ b/src/SystemWebAdapters/src/Ref.Standard.cs
@@ -302,18 +302,22 @@ namespace System.Web.Caching
 }
 namespace System.Web.SessionState
 {
-    public partial class HttpSessionState
+    public partial class HttpSessionState : System.Collections.ICollection, System.Collections.IEnumerable
     {
         internal HttpSessionState() { }
         public int Count { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public bool IsNewSession { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public bool IsReadOnly { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public bool IsSynchronized { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public object this[string name] { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public string SessionID { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public object SyncRoot { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public int Timeout { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public void Abandon() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Add(string name, object value) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Clear() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        public void CopyTo(System.Array array, int index) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        public System.Collections.IEnumerator GetEnumerator() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Remove(string name) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void RemoveAll() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
     }

--- a/src/SystemWebAdapters/src/SessionState/HttpSessionState.cs
+++ b/src/SystemWebAdapters/src/SessionState/HttpSessionState.cs
@@ -1,11 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Web.Adapters;
 
 namespace System.Web.SessionState;
 
-public class HttpSessionState
+public class HttpSessionState : ICollection
 {
     private readonly ISessionState _container;
 
@@ -28,6 +29,10 @@ public class HttpSessionState
         set => _container.Timeout = value;
     }
 
+    public bool IsSynchronized => _container.IsSynchronized;
+
+    public object SyncRoot => _container.SyncRoot;
+
     public void Abandon() => _container.Abandon();
 
     public object? this[string name]
@@ -36,11 +41,15 @@ public class HttpSessionState
         set => _container[name] = value;
     }
 
-    public void Add(string name, object value) => _container.Add(name,value);
+    public void Add(string name, object value) => _container.Add(name, value);
 
     public void Remove(string name) => _container.Remove(name);
 
     public void RemoveAll() => _container.Clear();
 
     public void Clear() => _container.Clear();
+
+    public void CopyTo(Array array, int index) => _container.CopyTo(array, index);
+
+    public IEnumerator GetEnumerator() => _container.GetEnumerator();
 }

--- a/src/SystemWebAdapters/src/SessionState/HttpSessionState.cs
+++ b/src/SystemWebAdapters/src/SessionState/HttpSessionState.cs
@@ -51,5 +51,5 @@ public class HttpSessionState : ICollection
 
     public void CopyTo(Array array, int index) => _container.CopyTo(array, index);
 
-    public IEnumerator GetEnumerator() => _container.GetEnumerator();
+    public IEnumerator GetEnumerator() => _container.Keys.GetEnumerator();
 }

--- a/src/SystemWebAdapters/src/TypeForwards.Framework.cs
+++ b/src/SystemWebAdapters/src/TypeForwards.Framework.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpBrowserCapabilities))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpContext))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpContextBase))]
@@ -18,5 +15,19 @@
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpSessionStateBase))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpSessionStateWrapper))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.SameSiteMode))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.BufferResponseStreamAttribute))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.DelegatingSessionState))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.IBufferResponseStreamMetadata))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.IPreBufferRequestStreamMetadata))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISessionManager))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISessionMetadata))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISessionState))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISystemWebAdapterBuilder))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.PreBufferRequestStreamAttribute))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.RemoteAppSessionStateExtensions))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SessionAttribute))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SessionBehavior))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SystemWebAdaptersExtensions))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SessionState.RemoteAppSessionStateOptions))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Caching.Cache))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.SessionState.HttpSessionState))]

--- a/src/SystemWebAdapters/src/TypeForwards.Framework.cs
+++ b/src/SystemWebAdapters/src/TypeForwards.Framework.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpBrowserCapabilities))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpContext))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpContextBase))]
@@ -15,19 +18,5 @@
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpSessionStateBase))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpSessionStateWrapper))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.SameSiteMode))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.BufferResponseStreamAttribute))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.DelegatingSessionState))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.IBufferResponseStreamMetadata))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.IPreBufferRequestStreamMetadata))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISessionManager))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISessionMetadata))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISessionState))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.ISystemWebAdapterBuilder))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.PreBufferRequestStreamAttribute))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.RemoteAppSessionStateExtensions))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SessionAttribute))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SessionBehavior))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SystemWebAdaptersExtensions))]
-[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Adapters.SessionState.RemoteAppSessionStateOptions))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.Caching.Cache))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.SessionState.HttpSessionState))]

--- a/src/SystemWebAdapters/test/Adapters/SessionState/SessionStateSerialization.cs
+++ b/src/SystemWebAdapters/test/Adapters/SessionState/SessionStateSerialization.cs
@@ -10,6 +10,25 @@ namespace System.Web.Adapters.SessionState;
 public class SessionStateSerialization
 {
     [Fact]
+    public async Task NewSession()
+    {
+        // Arrange
+        const string PayLoad = @"{
+    ""IsNewSession"": true,
+}";
+        var serializer = new SessionSerializer(new KeyDictionary());
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(PayLoad));
+
+        // Act
+        var result = await serializer.DeserializeAsync(stream);
+
+        // Assert
+        //Assert.NotNull(result);
+        //Assert.Equal(0, result!.Count);
+    }
+
+    [Fact]
     public async Task SingleValueInt()
     {
         // Arrange
@@ -63,18 +82,27 @@ public class SessionStateSerialization
         var str = GetStream(result);
 
         // Assert
-        const string Expected = @"{
+#if NETCOREAPP3_1
+const string Expected= @"{
   ""SessionID"": ""5"",
   ""IsReadOnly"": false,
   ""Values"": {
     ""Key1"": 5
   },
-  ""Count"": 1,
   ""Timeout"": 0,
   ""IsNewSession"": false,
   ""IsAbandoned"": false
 }";
-        Assert.Equal(Expected, str);
+
+#else
+        const string Expected = @"{
+  ""SessionID"": ""5"",
+  ""Values"": {
+    ""Key1"": 5
+  }
+}";
+#endif
+    Assert.Equal(Expected, str);
     }
 
     private string GetStream(MemoryStream stream)

--- a/src/SystemWebAdapters/test/Adapters/SessionState/SessionStateSerialization.cs
+++ b/src/SystemWebAdapters/test/Adapters/SessionState/SessionStateSerialization.cs
@@ -24,8 +24,9 @@ public class SessionStateSerialization
         var result = await serializer.DeserializeAsync(stream);
 
         // Assert
-        //Assert.NotNull(result);
-        //Assert.Equal(0, result!.Count);
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.Count);
+        Assert.True(result.IsNewSession);
     }
 
     [Fact]
@@ -83,7 +84,7 @@ public class SessionStateSerialization
 
         // Assert
 #if NETCOREAPP3_1
-const string Expected= @"{
+        const string Expected = @"{
   ""SessionID"": ""5"",
   ""IsReadOnly"": false,
   ""Values"": {
@@ -102,7 +103,7 @@ const string Expected= @"{
   }
 }";
 #endif
-    Assert.Equal(Expected, str);
+        Assert.Equal(Expected, str);
     }
 
     private string GetStream(MemoryStream stream)


### PR DESCRIPTION
This adds an enum that allows for setting behavior for session to be none, eager loading (i.e. async in middleware), and on-demand that will only be when it is used.