### PR TITLE
Add instrumentation to adapters

### DIFF
--- a/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Instrumentation.cs
+++ b/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Instrumentation.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+

--- a/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/PreBufferRequestStreamMiddleware.cs
+++ b/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/PreBufferRequestStreamMiddleware.cs
@@ -1,23 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
 internal class PreBufferRequestStreamMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly ILogger<PreBufferRequestStreamMiddleware> _logger;
 
-    public PreBufferRequestStreamMiddleware(RequestDelegate next, ILogger<PreBufferRequestStreamMiddleware> logger)
-    {
-        _next = next;
-        _logger = logger;
-    }
+    public PreBufferRequestStreamMiddleware(RequestDelegate next) => _next = next;
 
     public Task InvokeAsync(HttpContextCore context)
         => context.GetEndpoint()?.Metadata.GetMetadata<IPreBufferRequestStreamMetadata>() is { IsEnabled: true } metadata
@@ -27,12 +22,19 @@ internal class PreBufferRequestStreamMiddleware
     private async Task PreBufferAsync(HttpContextCore context, IPreBufferRequestStreamMetadata metadata)
     {
         // TODO: Should this enforce MaxRequestBodySize? https://github.com/aspnet/AspLabs/pull/447#discussion_r827314309
-        _logger.LogTrace("Buffering request stream");
-
+#if NET6_0_OR_GREATER
+        using (var activity = HttpContextAdapter.Source.StartActivity("PreBufferRequest"))
+        {
+            activity?.AddTag("BufferThreshold", metadata.BufferThreshold);
+            activity?.AddTag("BufferLimit", metadata.BufferLimit);
+#else
+        {
+#endif
         context.Request.EnableBuffering(metadata.BufferThreshold, metadata.BufferLimit ?? long.MaxValue);
 
-        await context.Request.Body.DrainAsync(context.RequestAborted);
-        context.Request.Body.Position = 0;
+            await context.Request.Body.DrainAsync(context.RequestAborted);
+            context.Request.Body.Position = 0;
+        }
 
         await _next(context);
     }

--- a/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
+++ b/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Security.Principal;
+using System.Threading.Tasks;
 using System.Web.Caching;
 using System.Web.SessionState;
 using Microsoft.AspNetCore.Http;
@@ -18,6 +20,12 @@ public class HttpContext : IServiceProvider
 
     private readonly HttpContextCore _context;
 
+#if NET6_0_OR_GREATER
+    internal static ActivitySource Source { get; } = new("Microsoft.AspNetCore.SystemWebAdapters");
+
+    private readonly Activity? _activity;
+#endif
+
     private HttpRequest? _request;
     private HttpResponse? _response;
     private HttpServerUtility? _server;
@@ -28,15 +36,69 @@ public class HttpContext : IServiceProvider
     public HttpContext(HttpContextCore context)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+
+#if NET6_0_OR_GREATER
+        _activity = Source.StartActivity("HttpContext");
+
+        if (_activity is not null)
+        {
+            if (_context.GetEndpoint() is { } endpoint)
+            {
+                _activity.AddTag("Endpoint", endpoint);
+            }
+
+            context.Response.OnCompleted(static state =>
+            {
+                ((Activity)state).Stop();
+                return Task.CompletedTask;
+            }, _activity);
+        }
+#endif
     }
 
-    public HttpRequest Request => _request ??= new(_context.Request);
+    public HttpRequest Request
+    {
+        get
+        {
+#if NET6_0_OR_GREATER
+            _activity?.AddEvent(new ActivityEvent(nameof(Request)));
+#endif
+            return _request ??= new(_context.Request);
+        }
+    }
 
-    public HttpResponse Response => _response ??= new(_context.Response);
+    public HttpResponse Response
+    {
+        get
+        {
+#if NET6_0_OR_GREATER
+            _activity?.AddEvent(new ActivityEvent(nameof(Response)));
+#endif
+            return _response ??= new(_context.Response);
+        }
+    }
 
-    public IDictionary Items => _items ??= _context.Items.AsNonGeneric();
+    public IDictionary Items
+    {
+        get
+        {
+#if NET6_0_OR_GREATER
+            _activity?.AddEvent(new ActivityEvent(nameof(Items)));
+#endif
+            return _items ??= _context.Items.AsNonGeneric();
+        }
+    }
 
-    public HttpServerUtility Server => _server ??= new(_context);
+    public HttpServerUtility Server
+    {
+        get
+        {
+#if NET6_0_OR_GREATER
+            _activity?.AddEvent(new ActivityEvent(nameof(Server)));
+#endif
+            return _server ??= new(_context);
+        }
+    }
 
     public Cache Cache => throw new NotImplementedException();
 
@@ -46,7 +108,16 @@ public class HttpContext : IServiceProvider
         set => _context.User = value is ClaimsPrincipal claims ? claims : new ClaimsPrincipal(value);
     }
 
-    public HttpSessionState? Session => _context.Features.Get<HttpSessionState>();
+    public HttpSessionState? Session
+    {
+        get
+        {
+#if NET6_0_OR_GREATER
+            _activity?.AddEvent(new ActivityEvent(nameof(Session)));
+#endif
+            return _context.Features.Get<HttpSessionState>();
+        }
+    }
 
     object? IServiceProvider.GetService(Type service)
     {

--- a/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -42,6 +42,7 @@
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
+    <Using Include="System.Web.HttpContext" Alias="HttpContextAdapter" />
     <Using Include="Microsoft.AspNetCore.Http.HttpContext" Alias="HttpContextCore" />
     <Using Include="Microsoft.AspNetCore.Http.HttpResponse" Alias="HttpResponseCore" />
     <Using Include="Microsoft.AspNetCore.Http.HttpRequest" Alias="HttpRequestCore" />


### PR DESCRIPTION
This enables the ability to track how much effect the adapters are having on the execution of endpoints. This will also allow us to identify unnecessary work that is being done (i.e. session is turned on, but not being used), as well as how much reliance an endpoint has on the adapters.
