### PR TITLE
Change AddHeader to Append

### DIFF
--- a/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/SystemWebAdapters/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -150,7 +150,7 @@ namespace System.Web
 
         public bool IsClientConnected => !_response.HttpContext.RequestAborted.IsCancellationRequested;
 
-        public void AddHeader(string name, string value) => _response.Headers.Add(name, value);
+        public void AddHeader(string name, string value) => AppendHeader(name, value);
 
         public void AppendHeader(string name, string value)
         {


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.web.httpresponse.addheader?view=netframework-4.8
"[AddHeader](https://docs.microsoft.com/en-us/dotnet/api/system.web.httpresponse.addheader?view=netframework-4.8) is the same as [AppendHeader](https://docs.microsoft.com/en-us/dotnet/api/system.web.httpresponse.appendheader?view=netframework-4.8) and is provided only for compatibility with earlier versions of ASP. With ASP.NET, use [AppendHeader](https://docs.microsoft.com/en-us/dotnet/api/system.web.httpresponse.appendheader?view=netframework-4.8)."

As opposed to AspNetCore Headers.Add which uses the Dictionary behavior that will throw if there are duplicate header names.