### PR TITLE
Use `npm ci` everywhere

### DIFF
--- a/src/BlazorCustomElements/src/Microsoft.AspNetCore.Components.CustomElements/js/WebpackBuild.targets
+++ b/src/BlazorCustomElements/src/Microsoft.AspNetCore.Components.CustomElements/js/WebpackBuild.targets
@@ -14,8 +14,8 @@
   <Target Name="NpmInstall"
           Inputs="$(MSBuildThisFileDirectory)package-lock.json"
           Outputs="$(BaseIntermediateOutputPath)package-lock.json">
-    <Message Importance="high" Text="Running npm install..." />
-    <Exec Command="npm install" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+    <Message Importance="high" Text="Running npm clean install..." />
+    <Exec Command="npm ci" WorkingDirectory="$(MSBuildThisFileDirectory)" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)package-lock.json"
           DestinationFolder="$(BaseIntermediateOutputPath)" />
   </Target>

--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -4,7 +4,7 @@
     <ClientAssetsDirectory Condition="'$(ClientAssetsDirectory)' == ''">assets\</ClientAssetsDirectory>
     <ClientAssetsRestoreInputs Condition="'$(ClientAssetsRestoreInputs)' == ''">$(ClientAssetsDirectory)package-lock.json;$(ClientAssetsDirectory)package.json</ClientAssetsRestoreInputs>
     <ClientAssetsRestoreOutputs Condition="'$(ClientAssetsRestoreOutputs)' == ''">$(ClientAssetsDirectory)node_modules\.package-lock.json</ClientAssetsRestoreOutputs>
-    <ClientAssetsRestoreCommand Condition="'$(ClientAssetsRestoreCommand)' == ''">npm install</ClientAssetsRestoreCommand>
+    <ClientAssetsRestoreCommand Condition="'$(ClientAssetsRestoreCommand)' == ''">npm ci</ClientAssetsRestoreCommand>
     <ClientAssetsBuildCommand Condition="'$(ClientAssetsBuildCommand)' == ''">npm run build:$(Configuration)</ClientAssetsBuildCommand>
     <ClientAssetsBuildOutputParameter Condition="'$(ClientAssetsBuildOutputParameter)' == ''">--output-path</ClientAssetsBuildOutputParameter>
 


### PR DESCRIPTION
- avoid grabbing new `npm` packages w/o explicit (manual) action