### PR TITLE
explicitly identifying button type in paginator

### DIFF
--- a/src/QuickGrid/src/Microsoft.AspNetCore.Components.QuickGrid/Pagination/Paginator.razor
+++ b/src/QuickGrid/src/Microsoft.AspNetCore.Components.QuickGrid/Pagination/Paginator.razor
@@ -14,14 +14,14 @@
             }
         </div>
         <nav role="navigation">
-            <button class="go-first" @onclick="GoFirstAsync" disabled="@(!CanGoBack)" title="Go to first page" aria-title="Go to first page"></button>
-            <button class="go-previous" @onclick="GoPreviousAsync" disabled="@(!CanGoBack)" title="Go to previous page" aria-title="Go to previous page"></button>
+            <button class="go-first" type="button" @onclick="GoFirstAsync" disabled="@(!CanGoBack)" title="Go to first page" aria-title="Go to first page"></button>
+            <button class="go-previous" type="button" @onclick="GoPreviousAsync" disabled="@(!CanGoBack)" title="Go to previous page" aria-title="Go to previous page"></button>
             <div class="pagination-text">
                 Page <strong>@(Value.CurrentPageIndex + 1)</strong>
                 of <strong>@(Value.LastPageIndex + 1)</strong>
             </div>
-            <button class="go-next" @onclick="GoNextAsync" disabled="@(!CanGoForwards)" title="Go to next page" aria-title="Go to next page"></button>
-            <button class="go-last" @onclick="GoLastAsync" disabled="@(!CanGoForwards)" title="Go to last page" aria-title="Go to last page"></button>
+            <button class="go-next" type="button" @onclick="GoNextAsync" disabled="@(!CanGoForwards)" title="Go to next page" aria-title="Go to next page"></button>
+            <button class="go-last" type="button" @onclick="GoLastAsync" disabled="@(!CanGoForwards)" title="Go to last page" aria-title="Go to last page"></button>
         </nav>
     }
 </div>


### PR DESCRIPTION
As per the [HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type), if a button's `type` is not explicitly specified, then it defaults to a `submit` type button.  This causes issues if the default QuickGrid Paginator is placed inside of an EditForm, as clicking any nav button triggers the EditContext's validation.
