### PR TITLE
Add .Net 7 Check to ClientAssets

### DIFF
--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -47,7 +47,7 @@
       <FileWrites Include="$(IntermediateOutputPath)clientassetsbuild.complete.txt" />
 
       <Content
-        Condition="'$(TargetFramework)' != 'net6.0'"
+        Condition="'$(TargetFramework)' != 'net6.0' Or '$(TargetFramework)' != 'net7.0'"
         Include="@(_ClientAssetsBuildOutput)"
         Link="wwwroot\%(_ClientAssetsBuildOutput.RecursiveDir)\%(_ClientAssetsBuildOutput.FileName)%(_ClientAssetsBuildOutput.Extension)" />
 
@@ -58,7 +58,7 @@
       the ability to consume them from project references. As a workaround, we are using the Task directly on this package, to make sure this scenario works. In a future
       release we will address this by aligning DiscoverStaticWebAssets behavior with DefineStaticWebAssets to follow the same heuristics for determining the content root.
     -->
-    <DefineStaticWebAssets Condition="'$(TargetFramework)' == 'net6.0'"
+    <DefineStaticWebAssets Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'"
       CandidateAssets="@(_ClientAssetsBuildOutput)"
       SourceId="$(PackageId)"
       SourceType="Computed"

--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -47,7 +47,7 @@
       <FileWrites Include="$(IntermediateOutputPath)clientassetsbuild.complete.txt" />
 
       <Content
-        Condition="'$(TargetFramework)' &lt; 'net6.0'"
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) "
         Include="@(_ClientAssetsBuildOutput)"
         Link="wwwroot\%(_ClientAssetsBuildOutput.RecursiveDir)\%(_ClientAssetsBuildOutput.FileName)%(_ClientAssetsBuildOutput.Extension)" />
 
@@ -58,7 +58,7 @@
       the ability to consume them from project references. As a workaround, we are using the Task directly on this package, to make sure this scenario works. In a future
       release we will address this by aligning DiscoverStaticWebAssets behavior with DefineStaticWebAssets to follow the same heuristics for determining the content root.
     -->
-    <DefineStaticWebAssets Condition="'$(TargetFramework)' &gt;= 'net6.0'"
+    <DefineStaticWebAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '6.0'))"
       CandidateAssets="@(_ClientAssetsBuildOutput)"
       SourceId="$(PackageId)"
       SourceType="Computed"

--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -47,7 +47,7 @@
       <FileWrites Include="$(IntermediateOutputPath)clientassetsbuild.complete.txt" />
 
       <Content
-        Condition="'$(TargetFramework)' != 'net6.0' Or '$(TargetFramework)' != 'net7.0'"
+        Condition="'$(TargetFramework)' &lt; 'net6.0'"
         Include="@(_ClientAssetsBuildOutput)"
         Link="wwwroot\%(_ClientAssetsBuildOutput.RecursiveDir)\%(_ClientAssetsBuildOutput.FileName)%(_ClientAssetsBuildOutput.Extension)" />
 
@@ -58,7 +58,7 @@
       the ability to consume them from project references. As a workaround, we are using the Task directly on this package, to make sure this scenario works. In a future
       release we will address this by aligning DiscoverStaticWebAssets behavior with DefineStaticWebAssets to follow the same heuristics for determining the content root.
     -->
-    <DefineStaticWebAssets Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'"
+    <DefineStaticWebAssets Condition="'$(TargetFramework)' &gt;= 'net6.0'"
       CandidateAssets="@(_ClientAssetsBuildOutput)"
       SourceId="$(PackageId)"
       SourceType="Computed"

--- a/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ClientAssetsInputs Include="$(ClientAssetsDirectory)**" Exclude="$(DefaultItemExcludes)" />
+    <ProjectCapability Include="ClientAssetsAlpha"/>
   </ItemGroup>
 
   <Target Name="ClientAssetsRestore" BeforeTargets="$(ClientAssetsRestoreBeforeTargets)" Inputs="$(ClientAssetsRestoreInputs)" Outputs="$(ClientAssetsRestoreOutputs)">


### PR DESCRIPTION
While the effort continues to productionize Microsoft.AspNetCore.ClientAssets, there needs to be an updated check to make sure that customers upgrading to .Net 7 don't break.

CC @mkArtakMSFT 

Fixes dotnet/aspnetcore#45849