### PR TITLE
Set column title by using DisplayAttribute and DisplayNameAttribute

### DIFF
--- a/src/QuickGrid/src/Microsoft.AspNetCore.Components.QuickGrid/Columns/PropertyColumn.cs
+++ b/src/QuickGrid/src/Microsoft.AspNetCore.Components.QuickGrid/Columns/PropertyColumn.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Microsoft.AspNetCore.Components.QuickGrid;
@@ -65,7 +68,10 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, ISortBuil
 
         if (Title is null && Property.Body is MemberExpression memberExpression)
         {
-            Title = memberExpression.Member.Name;
+            var memberInfo = memberExpression.Member;
+            var displayName = memberInfo?.GetCustomAttribute(typeof(DisplayNameAttribute)) as DisplayNameAttribute;
+            var display = memberInfo?.GetCustomAttribute(typeof(DisplayAttribute)) as DisplayAttribute;
+            Title = displayName?.DisplayName ?? display?.Name ?? memberInfo?.Name ?? "";            
         }
     }
 


### PR DESCRIPTION
This code uses the DisplayName and Display attributes to obtain the display name of a property. It starts by getting the member information from the provided member expression using the Member property of the memberExpression object. Then, it uses the GetCustomAttribute method to get the DisplayName and Display attributes associated with this member. If the DisplayName attribute is present, its value is used as the title. Otherwise, if the Display attribute is present, its Name property is used as the title. If neither of these attributes is present, the name of the member itself is used as the title. Finally, the value of the title is assigned to the Title property.