### PR TITLE
Upgrade System.Net.Http from 4.1.0 to 4.3.4 to fix the vulnerability (CVE-2022-34716)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,4 +28,10 @@
     -->
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
+
+  <!-- Bump NETStandard.Library to a version that doesn't transitively reference a System.Net.Http that causes CG alerts -->
+  <ItemGroup Condition="'$(IsUnitTestProject)' == 'true'">
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/AspNetCoreWebAPI/src/System.Web.Http.AspNetCore/System.Web.Http.AspNetCore.csproj
+++ b/src/AspNetCoreWebAPI/src/System.Web.Http.AspNetCore/System.Web.Http.AspNetCore.csproj
@@ -11,4 +11,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Bump NETStandard.Library to a version that doesn't transitively reference a System.Net.Http that causes CG alerts -->
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.IntegrationTests/Microsoft.AspNetCore.Grpc.HttpApi.IntegrationTests.csproj
+++ b/src/GrpcHttpApi/test/Microsoft.AspNetCore.Grpc.HttpApi.IntegrationTests/Microsoft.AspNetCore.Grpc.HttpApi.IntegrationTests.csproj
@@ -26,4 +26,9 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Bump NETStandard.Library to a version that doesn't transitively reference a System.Net.Http that causes CG alerts -->
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Address https://dev.azure.com/dnceng/internal/_componentGovernance/aspnet-AspLabs/alert/4810315?typeId=6333718 per https://github.com/dotnet/aspnetcore-internal/issues/4372#issuecomment-1720398783