### PR TITLE
Enhance XML comment extraction for Swagger docs

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+  "areaPath": "DevDiv\\ASP.NET Core\\Policy Violations",
+  "codebaseName": "AspLabs",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "aspnetcore-build@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "AspLabs",
+  "template": "TFSDEVDIV"
+}

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -102,7 +102,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: macOS-11
+          vmImage: macOS-12
         strategy:
           matrix:
             debug:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ extends:
           - job: macOS
             pool:
               name: Azure Pipelines
-              image: macOS-11
+              image: macOS-12
               os: macOS
             strategy:
               matrix:

--- a/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsDocumentFilter.cs
+++ b/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsDocumentFilter.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments
     {
         private const string MemberXPath = "/doc/members/member[@name='{0}']";
         private const string SummaryTag = "summary";
+        private const string ValueTag = "value";
 
         private readonly XPathNavigator _xmlNavigator;
 
@@ -56,10 +57,11 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments
             var memberName = XmlCommentsNodeNameHelper.GetMemberNameForType(type);
             var typeNode = _xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
 
-            if (typeNode != null)
+            if (typeNode is not null)
             {
-                var summaryNode = typeNode.SelectSingleNode(SummaryTag);
-                if (summaryNode != null)
+                var valueNode = typeNode.SelectSingleNode(ValueTag)
+                    ?? typeNode.SelectSingleNode(SummaryTag);
+                if (valueNode != null)
                 {
                     if (swaggerDoc.Tags == null)
                         swaggerDoc.Tags = new List<OpenApiTag>();
@@ -67,7 +69,7 @@ namespace Microsoft.AspNetCore.Grpc.Swagger.Internal.XmlComments
                     swaggerDoc.Tags.Add(new OpenApiTag
                     {
                         Name = nameAndType.Key,
-                        Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml)
+                        Description = XmlCommentsTextHelper.Humanize(valueNode.InnerXml)
                     });
                 }
                 return true;


### PR DESCRIPTION
Update GrpcXmlCommentsDocumentFilter.cs to prioritize "value" XML tags for Swagger descriptions, falling back to "summary" tags if "value" is not present. Introduce `ValueTag` constant and modernize null checks with `is not null` syntax. This improves the accuracy and specificity of the generated Swagger documentation.
