### PR TITLE
Fix generic type handling

### DIFF
--- a/src/OpenApiXmlCommentGenerator/gen/Helpers/INamedTypeSymbolExtensions.cs
+++ b/src/OpenApiXmlCommentGenerator/gen/Helpers/INamedTypeSymbolExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.CodeAnalysis;
 
 public static class INamedTypeSymbolExtensions
@@ -16,4 +17,26 @@ public static class INamedTypeSymbolExtensions
             Accessibility.Public => true,
             _ => true,    //Here should be some reasonable default
         };
+
+    /// <summary>
+    /// Converts a type symbol to its normalized display string representation. For generic types, this returns the
+    /// unbounded generic form (e.g., "IMarker` `" instead of "IMarker`T`"). For non-generic types, returns the
+    /// standard display string.
+    /// </summary>
+    /// <param name="symbol">The type symbol to convert</param>
+    /// <param name="format">Optional display format settings</param>
+    /// <returns>A normalized string representation of the type</returns>
+    public static string ToNormalizedDisplayString(this INamedTypeSymbol symbol, SymbolDisplayFormat? format = null)
+    {
+        if (symbol == null)
+            throw new ArgumentNullException(nameof(symbol));
+
+        if (symbol.IsGenericType)
+        {
+            var genericType = symbol.ConstructUnboundGenericType();
+            return genericType.ToDisplayString(format);
+        }
+
+        return symbol.ToDisplayString(format);
+    }
 }

--- a/src/OpenApiXmlCommentGenerator/gen/XmlCommentGenerator.Parser.cs
+++ b/src/OpenApiXmlCommentGenerator/gen/XmlCommentGenerator.Parser.cs
@@ -30,7 +30,7 @@ public sealed partial class XmlCommentGenerator
                 cancellationToken: cancellationToken);
             if (!string.IsNullOrEmpty(comment) && !string.Equals("<doc />", comment, StringComparison.Ordinal))
             {
-                var typeInfo = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                var typeInfo = type.ToNormalizedDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 var typeComment = XmlComment.Parse(comment, new());
                 comments.Add((typeInfo, null, typeComment));
             }
@@ -46,7 +46,7 @@ public sealed partial class XmlCommentGenerator
                 cancellationToken: cancellationToken);
             if (!string.IsNullOrEmpty(comment) && !string.Equals("<doc />", comment, StringComparison.Ordinal))
             {
-                var typeInfo = property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                var typeInfo = property.ContainingType.ToNormalizedDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 var propertyInfo = property.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 var propertyComment = XmlComment.Parse(comment, new());
                 if (propertyComment is not null)
@@ -72,7 +72,7 @@ public sealed partial class XmlCommentGenerator
                 {
                     continue;
                 }
-                var typeInfo = method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                var typeInfo = method.ContainingType.ToNormalizedDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 var methodInfo = method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 comments.Add((typeInfo, methodInfo, XmlComment.Parse(comment, new())));
             }


### PR DESCRIPTION
Love the direction `Microsoft.AspNetCore.OpenApi.SourceGenerators` is going, but there's a bug when extracting comments from types that support generics. The issue is in [https://github.com/aspnet/AspLabs/blob/main/src/OpenApiXmlCommentGenerator/gen/XmlCommentGenerator.Parser.cs](https://github.com/aspnet/AspLabs/blob/main/src/OpenApiXmlCommentGenerator/gen/XmlCommentGenerator.Parser.cs), specifically in these lines of code:

```csharp
var typeInfo = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
var typeInfo = property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
```

To fix this, I've added a new method `ToNormalizedDisplayString` to `INamedTypeSymbolExtensions.cs`. The method checks if the type is generic - if so, it constructs an unbounded generic type (which works well for the comment caching strategy) and uses that for the display name. Otherwise, it uses the general type:

```csharp
public static string ToNormalizedDisplayString(this INamedTypeSymbol symbol, SymbolDisplayFormat? format = null)  
{  
    if (symbol.IsGenericType)  
    {        var genericType = symbol.ConstructUnboundGenericType();  
        return genericType.ToDisplayString(format);  
    }  
    return symbol.ToDisplayString(format);  
}
```

Looking forward to the general release. Thanks for your efforts!