### PR TITLE
Add Dependabot config for monthly NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,14 @@ updates:
     directory: "/"
     registries:
       - dotnet-public
-    open-pull-requests-limit: 5
     schedule:
       interval: "monthly"
     labels:
       - "area-infrastructure"
+    groups:
+      nuget:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+registries:
+  dotnet-public:
+    type: nuget-feed
+    url: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    registries:
+      - dotnet-public
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "monthly"
+    labels:
+      - "area-infrastructure"


### PR DESCRIPTION
Adds a dependabot config that updates NuGet packages monthly on `main`.